### PR TITLE
Migrations and stuff

### DIFF
--- a/db/archived/20151103034459_devise_create_users.rb
+++ b/db/archived/20151103034459_devise_create_users.rb
@@ -1,4 +1,4 @@
-class DeviseCreateUsers < ActiveRecord::Migration[4.2]
+class DeviseCreateUsers < ActiveRecord::Migration
   def change
     create_table(:users) do |t|
       ## Database authenticatable

--- a/db/archived/20151103202810_create_workshops.rb
+++ b/db/archived/20151103202810_create_workshops.rb
@@ -1,4 +1,4 @@
-class CreateWorkshops < ActiveRecord::Migration[4.2]
+class CreateWorkshops < ActiveRecord::Migration
   def change
     create_table :workshops do |t|
       t.string :title

--- a/db/archived/20151103212212_create_sectors.rb
+++ b/db/archived/20151103212212_create_sectors.rb
@@ -1,4 +1,4 @@
-class CreateSectors < ActiveRecord::Migration[4.2]
+class CreateSectors < ActiveRecord::Migration
   def change
     create_table :sectors do |t|
       t.string :name

--- a/db/archived/20151103212242_create_workshop_sectors.rb
+++ b/db/archived/20151103212242_create_workshop_sectors.rb
@@ -1,4 +1,4 @@
-class CreateWorkshopSectors < ActiveRecord::Migration[4.2]
+class CreateWorkshopSectors < ActiveRecord::Migration
   def change
     create_table :workshop_sectors do |t|
       t.references :workshop, index: true

--- a/db/archived/20151104004208_create_resources.rb
+++ b/db/archived/20151104004208_create_resources.rb
@@ -1,4 +1,4 @@
-class CreateResources < ActiveRecord::Migration[4.2]
+class CreateResources < ActiveRecord::Migration
   def change
     create_table :resources do |t|
       t.string :title

--- a/db/archived/20151104013011_create_images.rb
+++ b/db/archived/20151104013011_create_images.rb
@@ -1,5 +1,5 @@
 
-class CreateImages < ActiveRecord::Migration[4.2]
+class CreateImages < ActiveRecord::Migration
   def change
     create_table :images do |t|
       t.integer :owner_id, index: true

--- a/db/archived/20151104013623_add_attachment_file_to_images.rb
+++ b/db/archived/20151104013623_add_attachment_file_to_images.rb
@@ -1,4 +1,4 @@
-class AddAttachmentFileToImages < ActiveRecord::Migration[4.2]
+class AddAttachmentFileToImages < ActiveRecord::Migration
   def self.up
     change_table :images do |t|
       t.attachment :file

--- a/db/archived/20151107042840_devise_create_admins.rb
+++ b/db/archived/20151107042840_devise_create_admins.rb
@@ -1,4 +1,4 @@
-class DeviseCreateAdmins < ActiveRecord::Migration[4.2]
+class DeviseCreateAdmins < ActiveRecord::Migration
   def change
     create_table(:admins) do |t|
       ## Database authenticatable

--- a/db/archived/20151107235718_add_resource_type_to_resources.rb
+++ b/db/archived/20151107235718_add_resource_type_to_resources.rb
@@ -1,4 +1,4 @@
-class AddResourceTypeToResources < ActiveRecord::Migration[4.2]
+class AddResourceTypeToResources < ActiveRecord::Migration
   def change
     add_column :resources, :type, :string
   end

--- a/db/archived/20151110201934_create_workshop_logs.rb
+++ b/db/archived/20151110201934_create_workshop_logs.rb
@@ -1,4 +1,4 @@
-class CreateWorkshopLogs < ActiveRecord::Migration[4.2]
+class CreateWorkshopLogs < ActiveRecord::Migration
   def change
     create_table :workshop_logs do |t|
       t.references :workshop, index: true

--- a/db/archived/20151110203108_create_locations.rb
+++ b/db/archived/20151110203108_create_locations.rb
@@ -1,4 +1,4 @@
-class CreateLocations < ActiveRecord::Migration[4.2]
+class CreateLocations < ActiveRecord::Migration
   def change
     create_table :locations do |t|
       t.string :city

--- a/db/archived/20151110203201_create_agencies.rb
+++ b/db/archived/20151110203201_create_agencies.rb
@@ -1,4 +1,4 @@
-class CreateAgencies < ActiveRecord::Migration[4.2]
+class CreateAgencies < ActiveRecord::Migration
   def change
     create_table :agencies do |t|
     t.string :name

--- a/db/archived/20151110203656_add_agency_id_to_users.rb
+++ b/db/archived/20151110203656_add_agency_id_to_users.rb
@@ -1,4 +1,4 @@
-class AddAgencyIdToUsers < ActiveRecord::Migration[4.2]
+class AddAgencyIdToUsers < ActiveRecord::Migration
   def change
     add_reference :users, :agency, index: true
     add_foreign_key :users, :agencies

--- a/db/archived/20151112200413_create_sectorable_items.rb
+++ b/db/archived/20151112200413_create_sectorable_items.rb
@@ -1,4 +1,4 @@
-class CreateSectorableItems < ActiveRecord::Migration[4.2]
+class CreateSectorableItems < ActiveRecord::Migration
   def change
     create_table :sectorable_items do |t|
       t.integer :sectorable_id

--- a/db/archived/20151112200423_remove_workshop_sectors.rb
+++ b/db/archived/20151112200423_remove_workshop_sectors.rb
@@ -1,4 +1,4 @@
-class RemoveWorkshopSectors < ActiveRecord::Migration[4.2]
+class RemoveWorkshopSectors < ActiveRecord::Migration
   def change
     drop_table :workshop_sectors
   end

--- a/db/archived/20151116005500_create_bookmarks.rb
+++ b/db/archived/20151116005500_create_bookmarks.rb
@@ -1,4 +1,4 @@
-class CreateBookmarks < ActiveRecord::Migration[4.2]
+class CreateBookmarks < ActiveRecord::Migration
   def change
     create_table :bookmarks do |t|
       t.references :user, index: true

--- a/db/archived/20151116051734_add_workshop_id_to_resources.rb
+++ b/db/archived/20151116051734_add_workshop_id_to_resources.rb
@@ -1,4 +1,4 @@
-class AddWorkshopIdToResources < ActiveRecord::Migration[4.2]
+class AddWorkshopIdToResources < ActiveRecord::Migration
   def change
     add_reference :resources, :workshop, index: true
     add_foreign_key :resources, :workshops

--- a/db/archived/20151116064620_create_workshop_variations.rb
+++ b/db/archived/20151116064620_create_workshop_variations.rb
@@ -1,4 +1,4 @@
-class CreateWorkshopVariations < ActiveRecord::Migration[4.2]
+class CreateWorkshopVariations < ActiveRecord::Migration
   def change
     create_table :workshop_variations do |t|
       t.references :workshop, index: true

--- a/db/archived/20151116194043_add_activation_status_to_users.rb
+++ b/db/archived/20151116194043_add_activation_status_to_users.rb
@@ -1,4 +1,4 @@
-class AddActivationStatusToUsers < ActiveRecord::Migration[4.2]
+class AddActivationStatusToUsers < ActiveRecord::Migration
   def change
     add_column :users, :activation_status, :integer, default: 0
   end

--- a/db/archived/20151118004850_create_project_leaders.rb
+++ b/db/archived/20151118004850_create_project_leaders.rb
@@ -1,4 +1,4 @@
-class CreateProjectLeaders < ActiveRecord::Migration[4.2]
+class CreateProjectLeaders < ActiveRecord::Migration
   def change
     create_table :project_leaders do |t|
       t.references :agency, index: true

--- a/db/archived/20151118010650_remove_leader_id_from_agencies.rb
+++ b/db/archived/20151118010650_remove_leader_id_from_agencies.rb
@@ -1,4 +1,4 @@
-class RemoveLeaderIdFromAgencies < ActiveRecord::Migration[4.2]
+class RemoveLeaderIdFromAgencies < ActiveRecord::Migration
   def change
     remove_column :agencies, :leader_id
   end

--- a/db/archived/20151118012535_create_permissions.rb
+++ b/db/archived/20151118012535_create_permissions.rb
@@ -1,4 +1,4 @@
-class CreatePermissions < ActiveRecord::Migration[4.2]
+class CreatePermissions < ActiveRecord::Migration
   def change
     create_table :permissions do |t|
       t.string :security_cat

--- a/db/archived/20151118012814_create_user_permissions.rb
+++ b/db/archived/20151118012814_create_user_permissions.rb
@@ -1,4 +1,4 @@
-class CreateUserPermissions < ActiveRecord::Migration[4.2]
+class CreateUserPermissions < ActiveRecord::Migration
   def change
     create_table :user_permissions do |t|
       t.references :user, index: true

--- a/db/archived/20151118020151_create_metadata.rb
+++ b/db/archived/20151118020151_create_metadata.rb
@@ -1,4 +1,4 @@
-class CreateMetadata < ActiveRecord::Migration[4.2]
+class CreateMetadata < ActiveRecord::Migration
   def change
     create_table :metadata do |t|
       t.string :name

--- a/db/archived/20151118020254_create_categories.rb
+++ b/db/archived/20151118020254_create_categories.rb
@@ -1,4 +1,4 @@
-class CreateCategories < ActiveRecord::Migration[4.2]
+class CreateCategories < ActiveRecord::Migration
   def change
     create_table :categories do |t|
       t.references :metadatum, index: true

--- a/db/archived/20151118020316_create_categorizable_items.rb
+++ b/db/archived/20151118020316_create_categorizable_items.rb
@@ -1,4 +1,4 @@
-class CreateCategorizableItems < ActiveRecord::Migration[4.2]
+class CreateCategorizableItems < ActiveRecord::Migration
   def change
     create_table :categorizable_items do |t|
       t.integer :categorizable_id

--- a/db/archived/20151120021943_create_windows_types.rb
+++ b/db/archived/20151120021943_create_windows_types.rb
@@ -1,4 +1,4 @@
-class CreateWindowsTypes < ActiveRecord::Migration[4.2]
+class CreateWindowsTypes < ActiveRecord::Migration
   def change
     create_table :windows_types do |t|
       t.string :name

--- a/db/archived/20151120021955_add_windows_type_id_to_workshops.rb
+++ b/db/archived/20151120021955_add_windows_type_id_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddWindowsTypeIdToWorkshops < ActiveRecord::Migration[4.2]
+class AddWindowsTypeIdToWorkshops < ActiveRecord::Migration
   def change
     add_reference :workshops, :windows_type, index: true
     add_foreign_key :workshops, :windows_types

--- a/db/archived/20151120025113_add_published_to_sectors.rb
+++ b/db/archived/20151120025113_add_published_to_sectors.rb
@@ -1,4 +1,4 @@
-class AddPublishedToSectors < ActiveRecord::Migration[4.2]
+class AddPublishedToSectors < ActiveRecord::Migration
   def change
     add_column :sectors, :published, :boolean, default: false
   end

--- a/db/archived/20151124193238_add_user_id_to_workshops.rb
+++ b/db/archived/20151124193238_add_user_id_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddUserIdToWorkshops < ActiveRecord::Migration[4.2]
+class AddUserIdToWorkshops < ActiveRecord::Migration
   def change
     add_reference :workshops, :user, index: true
     add_foreign_key :workshops, :users

--- a/db/archived/20151124194225_add_male_and_female_to_resources.rb
+++ b/db/archived/20151124194225_add_male_and_female_to_resources.rb
@@ -1,4 +1,4 @@
-class AddMaleAndFemaleToResources < ActiveRecord::Migration[4.2]
+class AddMaleAndFemaleToResources < ActiveRecord::Migration
   def change
     add_column :resources, :male, :boolean, default: false
     add_column :resources, :female, :boolean, default: false

--- a/db/archived/20151124215141_create_forms.rb
+++ b/db/archived/20151124215141_create_forms.rb
@@ -1,4 +1,4 @@
-class CreateForms < ActiveRecord::Migration[4.2]
+class CreateForms < ActiveRecord::Migration
   def change
     create_table :forms do |t|
       t.string :owner_type

--- a/db/archived/20151124215152_create_form_fields.rb
+++ b/db/archived/20151124215152_create_form_fields.rb
@@ -1,4 +1,4 @@
-class CreateFormFields < ActiveRecord::Migration[4.2]
+class CreateFormFields < ActiveRecord::Migration
   def change
     create_table :form_fields do |t|
       t.string :label

--- a/db/archived/20151124215209_create_user_forms.rb
+++ b/db/archived/20151124215209_create_user_forms.rb
@@ -1,4 +1,4 @@
-class CreateUserForms < ActiveRecord::Migration[4.2]
+class CreateUserForms < ActiveRecord::Migration
   def change
     create_table :user_forms do |t|
       t.references :user, index: true

--- a/db/archived/20151124215334_create_user_form__form_fields.rb
+++ b/db/archived/20151124215334_create_user_form__form_fields.rb
@@ -1,4 +1,4 @@
-class CreateUserFormFormFields < ActiveRecord::Migration[4.2]
+class CreateUserFormFormFields < ActiveRecord::Migration
   def change
     create_table :user_form_form_fields do |t|
       t.references :form_field, index: true

--- a/db/archived/20151125201418_add_phone_to_users.rb
+++ b/db/archived/20151125201418_add_phone_to_users.rb
@@ -1,4 +1,4 @@
-class AddPhoneToUsers < ActiveRecord::Migration[4.2]
+class AddPhoneToUsers < ActiveRecord::Migration
   def change
     add_column :users, :phone, :string
   end

--- a/db/archived/20151130202744_create_faqs.rb
+++ b/db/archived/20151130202744_create_faqs.rb
@@ -1,4 +1,4 @@
-class CreateFaqs < ActiveRecord::Migration[4.2]
+class CreateFaqs < ActiveRecord::Migration
   def change
     create_table :faqs do |t|
       t.string :question

--- a/db/archived/20151201185543_add_fields_to_users.rb
+++ b/db/archived/20151201185543_add_fields_to_users.rb
@@ -1,4 +1,4 @@
-class AddFieldsToUsers < ActiveRecord::Migration[4.2]
+class AddFieldsToUsers < ActiveRecord::Migration
   def change
     add_column :users, :address, :string
     add_column :users, :city, :string

--- a/db/archived/20151203204501_add_fields_to_agencies.rb
+++ b/db/archived/20151203204501_add_fields_to_agencies.rb
@@ -1,4 +1,4 @@
-class AddFieldsToAgencies < ActiveRecord::Migration[4.2]
+class AddFieldsToAgencies < ActiveRecord::Migration
   def change
     add_reference :agencies, :windows_type, index: true
     add_foreign_key :agencies, :windows_types

--- a/db/archived/20151203211929_create_project_statuses.rb
+++ b/db/archived/20151203211929_create_project_statuses.rb
@@ -1,4 +1,4 @@
-class CreateProjectStatuses < ActiveRecord::Migration[4.2]
+class CreateProjectStatuses < ActiveRecord::Migration
   def change
     create_table :project_statuses do |t|
       t.string :name

--- a/db/archived/20151203212116_create_project_obligations.rb
+++ b/db/archived/20151203212116_create_project_obligations.rb
@@ -1,4 +1,4 @@
-class CreateProjectObligations < ActiveRecord::Migration[4.2]
+class CreateProjectObligations < ActiveRecord::Migration
   def change
     create_table :project_obligations do |t|
       t.string :name

--- a/db/archived/20151203212451_rename_agencies_to_projects.rb
+++ b/db/archived/20151203212451_rename_agencies_to_projects.rb
@@ -1,4 +1,4 @@
-class RenameAgenciesToProjects < ActiveRecord::Migration[4.2]
+class RenameAgenciesToProjects < ActiveRecord::Migration
   def change
     rename_table :agencies, :projects
   end

--- a/db/archived/20151203212722_add_project_id_to_project_leaders.rb
+++ b/db/archived/20151203212722_add_project_id_to_project_leaders.rb
@@ -1,4 +1,4 @@
-class AddProjectIdToProjectLeaders < ActiveRecord::Migration[4.2]
+class AddProjectIdToProjectLeaders < ActiveRecord::Migration
   def change
     add_reference :project_leaders, :project, index: true
     add_foreign_key :project_leaders, :projects

--- a/db/archived/20151203213053_add_filemaker_code_to_project_leaders.rb
+++ b/db/archived/20151203213053_add_filemaker_code_to_project_leaders.rb
@@ -1,4 +1,4 @@
-class AddFilemakerCodeToProjectLeaders < ActiveRecord::Migration[4.2]
+class AddFilemakerCodeToProjectLeaders < ActiveRecord::Migration
   def change
     add_column :project_leaders, :filemaker_code, :string
   end

--- a/db/archived/20151203213136_rename_project_leaders_to_project_users.rb
+++ b/db/archived/20151203213136_rename_project_leaders_to_project_users.rb
@@ -1,4 +1,4 @@
-class RenameProjectLeadersToProjectUsers < ActiveRecord::Migration[4.2]
+class RenameProjectLeadersToProjectUsers < ActiveRecord::Migration
   def change
     rename_table :project_leaders, :project_users
   end

--- a/db/archived/20151203215238_remove_not_null_constraint_from_users_first_name.rb
+++ b/db/archived/20151203215238_remove_not_null_constraint_from_users_first_name.rb
@@ -1,4 +1,4 @@
-class RemoveNotNullConstraintFromUsersFirstName < ActiveRecord::Migration[4.2]
+class RemoveNotNullConstraintFromUsersFirstName < ActiveRecord::Migration
   def change
     change_column :users, :first_name, :string, :null => true
     change_column :users, :last_name, :string, :null => true

--- a/db/archived/20151204000743_create_workshop_quotes.rb
+++ b/db/archived/20151204000743_create_workshop_quotes.rb
@@ -1,4 +1,4 @@
-class CreateWorkshopQuotes < ActiveRecord::Migration[4.2]
+class CreateWorkshopQuotes < ActiveRecord::Migration
   def change
     create_table :workshop_quotes do |t|
       t.string :quote

--- a/db/archived/20151204001417_add_workshop_id_to_workshop_quotes.rb
+++ b/db/archived/20151204001417_add_workshop_id_to_workshop_quotes.rb
@@ -1,4 +1,4 @@
-class AddWorkshopIdToWorkshopQuotes < ActiveRecord::Migration[4.2]
+class AddWorkshopIdToWorkshopQuotes < ActiveRecord::Migration
   def change
     add_reference :workshop_quotes, :workshop, index: true
     add_foreign_key :workshop_quotes, :workshops

--- a/db/archived/20151204001844_add_fields_to_faqs.rb
+++ b/db/archived/20151204001844_add_fields_to_faqs.rb
@@ -1,4 +1,4 @@
-class AddFieldsToFaqs < ActiveRecord::Migration[4.2]
+class AddFieldsToFaqs < ActiveRecord::Migration
   def change
     add_column :faqs, :inactive, :boolean
     add_column :faqs, :ordering, :integer

--- a/db/archived/20151204025408_create_bookmark_annotations.rb
+++ b/db/archived/20151204025408_create_bookmark_annotations.rb
@@ -1,4 +1,4 @@
-class CreateBookmarkAnnotations < ActiveRecord::Migration[4.2]
+class CreateBookmarkAnnotations < ActiveRecord::Migration
   def change
     create_table :bookmark_annotations do |t|
       t.references :bookmark, index: true

--- a/db/archived/20151207024433_create_monthly_reports.rb
+++ b/db/archived/20151207024433_create_monthly_reports.rb
@@ -1,4 +1,4 @@
-class CreateMonthlyReports < ActiveRecord::Migration[4.2]
+class CreateMonthlyReports < ActiveRecord::Migration
   def change
     create_table :monthly_reports do |t|
       t.string :month

--- a/db/archived/20151207035509_make_workshop_quotes_just_quotes.rb
+++ b/db/archived/20151207035509_make_workshop_quotes_just_quotes.rb
@@ -1,4 +1,4 @@
-class MakeWorkshopQuotesJustQuotes < ActiveRecord::Migration[4.2]
+class MakeWorkshopQuotesJustQuotes < ActiveRecord::Migration
   def change
     rename_table :workshop_quotes, :quotes
   end

--- a/db/archived/20151207040045_create_quotable_item_quotes.rb
+++ b/db/archived/20151207040045_create_quotable_item_quotes.rb
@@ -1,4 +1,4 @@
-class CreateQuotableItemQuotes < ActiveRecord::Migration[4.2]
+class CreateQuotableItemQuotes < ActiveRecord::Migration
   def change
     create_table :quotable_item_quotes do |t|
       t.string :quotable_type

--- a/db/archived/20151207185525_add_url_to_resources.rb
+++ b/db/archived/20151207185525_add_url_to_resources.rb
@@ -1,4 +1,4 @@
-class AddUrlToResources < ActiveRecord::Migration[4.2]
+class AddUrlToResources < ActiveRecord::Migration
   def change
     add_column :resources, :url, :string
   end

--- a/db/archived/20151211003610_add_project_id_to_workshop_logs.rb
+++ b/db/archived/20151211003610_add_project_id_to_workshop_logs.rb
@@ -1,4 +1,4 @@
-class AddProjectIdToWorkshopLogs < ActiveRecord::Migration[4.2]
+class AddProjectIdToWorkshopLogs < ActiveRecord::Migration
   def change
     add_reference :workshop_logs, :project, index: true
     add_foreign_key :workshop_logs, :projects

--- a/db/archived/20151211045430_add_inactive_to_resources.rb
+++ b/db/archived/20151211045430_add_inactive_to_resources.rb
@@ -1,4 +1,4 @@
-class AddInactiveToResources < ActiveRecord::Migration[4.2]
+class AddInactiveToResources < ActiveRecord::Migration
   def change
     add_column :resources, :inactive, :boolean, default: true
   end

--- a/db/archived/20151215181134_create_attachments.rb
+++ b/db/archived/20151215181134_create_attachments.rb
@@ -1,4 +1,4 @@
-class CreateAttachments < ActiveRecord::Migration[4.2]
+class CreateAttachments < ActiveRecord::Migration
   def change
     create_table :attachments do |t|
       t.integer :owner_id

--- a/db/archived/20151215181219_add_attachment_file_to_attachments.rb
+++ b/db/archived/20151215181219_add_attachment_file_to_attachments.rb
@@ -1,4 +1,4 @@
-class AddAttachmentFileToAttachments < ActiveRecord::Migration[4.2]
+class AddAttachmentFileToAttachments < ActiveRecord::Migration
   def self.up
     change_table :attachments do |t|
       t.attachment :file

--- a/db/archived/20151215185815_add_code_to_workshop_variations.rb
+++ b/db/archived/20151215185815_add_code_to_workshop_variations.rb
@@ -1,4 +1,4 @@
-class AddCodeToWorkshopVariations < ActiveRecord::Migration[4.2]
+class AddCodeToWorkshopVariations < ActiveRecord::Migration
   def change
     add_column :workshop_variations, :code, :text
     add_column :workshop_variations, :inactive, :boolean, default: true

--- a/db/archived/20151215190047_add_ordering_to_workshop_variations.rb
+++ b/db/archived/20151215190047_add_ordering_to_workshop_variations.rb
@@ -1,4 +1,4 @@
-class AddOrderingToWorkshopVariations < ActiveRecord::Migration[4.2]
+class AddOrderingToWorkshopVariations < ActiveRecord::Migration
   def change
     add_column :workshop_variations, :ordering, :integer
   end

--- a/db/archived/20151215190428_add_name_to_workshop_variations.rb
+++ b/db/archived/20151215190428_add_name_to_workshop_variations.rb
@@ -1,4 +1,4 @@
-class AddNameToWorkshopVariations < ActiveRecord::Migration[4.2]
+class AddNameToWorkshopVariations < ActiveRecord::Migration
   def change
     add_column :workshop_variations, :name, :string
   end

--- a/db/archived/20151215192706_add_legacy_to_workshop_variations.rb
+++ b/db/archived/20151215192706_add_legacy_to_workshop_variations.rb
@@ -1,4 +1,4 @@
-class AddLegacyToWorkshopVariations < ActiveRecord::Migration[4.2]
+class AddLegacyToWorkshopVariations < ActiveRecord::Migration
   def change
     add_column :workshop_variations, :legacy, :boolean, default: false
   end

--- a/db/archived/20151215192926_add_variation_id_to_workshop_variations.rb
+++ b/db/archived/20151215192926_add_variation_id_to_workshop_variations.rb
@@ -1,4 +1,4 @@
-class AddVariationIdToWorkshopVariations < ActiveRecord::Migration[4.2]
+class AddVariationIdToWorkshopVariations < ActiveRecord::Migration
   def change
     add_column :workshop_variations, :variation_id, :integer
   end

--- a/db/archived/20151215195035_add_fields_to_resources.rb
+++ b/db/archived/20151215195035_add_fields_to_resources.rb
@@ -1,4 +1,4 @@
-class AddFieldsToResources < ActiveRecord::Migration[4.2]
+class AddFieldsToResources < ActiveRecord::Migration
   def change
     add_column :resources, :agency, :string
     add_column :resources, :legacy, :boolean

--- a/db/archived/20151215201526_create_workshop_resources.rb
+++ b/db/archived/20151215201526_create_workshop_resources.rb
@@ -1,4 +1,4 @@
-class CreateWorkshopResources < ActiveRecord::Migration[4.2]
+class CreateWorkshopResources < ActiveRecord::Migration
   def change
     create_table :workshop_resources do |t|
       t.references :workshop, index: true

--- a/db/archived/20151215222920_add_logs_count_to_workshops.rb
+++ b/db/archived/20151215222920_add_logs_count_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddLogsCountToWorkshops < ActiveRecord::Migration[4.2]
+class AddLogsCountToWorkshops < ActiveRecord::Migration
   def change
     add_column :workshops, :led_count, :integer, default: 0
   end

--- a/db/archived/20151218003835_add_status_id_to_projects.rb
+++ b/db/archived/20151218003835_add_status_id_to_projects.rb
@@ -1,4 +1,4 @@
-class AddStatusIdToProjects < ActiveRecord::Migration[4.2]
+class AddStatusIdToProjects < ActiveRecord::Migration
   def change
     add_reference :projects, :project_status, index: true
     add_foreign_key :projects, :project_statuses

--- a/db/archived/20160107031515_change_quote_to_text.rb
+++ b/db/archived/20160107031515_change_quote_to_text.rb
@@ -1,4 +1,4 @@
-class ChangeQuoteToText < ActiveRecord::Migration[4.2]
+class ChangeQuoteToText < ActiveRecord::Migration
   def up
     change_column :quotes, :quote, :text
   end

--- a/db/archived/20160107050648_add_legacy_id_to_windows_types.rb
+++ b/db/archived/20160107050648_add_legacy_id_to_windows_types.rb
@@ -1,4 +1,4 @@
-class AddLegacyIdToWindowsTypes < ActiveRecord::Migration[4.2]
+class AddLegacyIdToWindowsTypes < ActiveRecord::Migration
   def change
     add_column :windows_types, :legacy_id, :integer
   end

--- a/db/archived/20160123034628_add_legacy_id_to_permissions.rb
+++ b/db/archived/20160123034628_add_legacy_id_to_permissions.rb
@@ -1,4 +1,4 @@
-class AddLegacyIdToPermissions < ActiveRecord::Migration[4.2]
+class AddLegacyIdToPermissions < ActiveRecord::Migration
   def change
     add_column :permissions, :legacy_id, :integer
   end

--- a/db/archived/20160225003842_create_age_ranges.rb
+++ b/db/archived/20160225003842_create_age_ranges.rb
@@ -1,4 +1,4 @@
-class CreateAgeRanges < ActiveRecord::Migration[4.2]
+class CreateAgeRanges < ActiveRecord::Migration
   def change
     create_table :age_ranges do |t|
       t.string :name

--- a/db/archived/20160225003910_create_workshop_age_ranges.rb
+++ b/db/archived/20160225003910_create_workshop_age_ranges.rb
@@ -1,4 +1,4 @@
-class CreateWorkshopAgeRanges < ActiveRecord::Migration[4.2]
+class CreateWorkshopAgeRanges < ActiveRecord::Migration
   def change
     create_table :workshop_age_ranges do |t|
       t.references :workshop, index: true

--- a/db/archived/20160225004448_add_windows_type_id_to_age_ranges.rb
+++ b/db/archived/20160225004448_add_windows_type_id_to_age_ranges.rb
@@ -1,4 +1,4 @@
-class AddWindowsTypeIdToAgeRanges < ActiveRecord::Migration[4.2]
+class AddWindowsTypeIdToAgeRanges < ActiveRecord::Migration
   def change
     add_reference :age_ranges, :windows_type, index: true
     add_foreign_key :age_ranges, :windows_types

--- a/db/archived/20160225225842_add_is_embodied_art_workshop_to_workshop_logs.rb
+++ b/db/archived/20160225225842_add_is_embodied_art_workshop_to_workshop_logs.rb
@@ -1,4 +1,4 @@
-class AddIsEmbodiedArtWorkshopToWorkshopLogs < ActiveRecord::Migration[4.2]
+class AddIsEmbodiedArtWorkshopToWorkshopLogs < ActiveRecord::Migration
   def change
     add_column :workshop_logs, :is_embodied_art_workshop, :boolean, default: false
   end

--- a/db/archived/20160302200835_add_participants_fields_to_workshop_logs.rb
+++ b/db/archived/20160302200835_add_participants_fields_to_workshop_logs.rb
@@ -1,4 +1,4 @@
-class AddParticipantsFieldsToWorkshopLogs < ActiveRecord::Migration[4.2]
+class AddParticipantsFieldsToWorkshopLogs < ActiveRecord::Migration
   def change
     add_column :workshop_logs, :num_participants_on_going, :integer, default: 0
     add_column :workshop_logs, :num_participants_first_time, :integer, default: 0

--- a/db/archived/20160302232505_create_form_builders.rb
+++ b/db/archived/20160302232505_create_form_builders.rb
@@ -1,4 +1,4 @@
-class CreateFormBuilders < ActiveRecord::Migration[4.2]
+class CreateFormBuilders < ActiveRecord::Migration
   def change
     create_table :form_builders do |t|
       t.string :name

--- a/db/archived/20160302233156_add_form_builder_to_forms.rb
+++ b/db/archived/20160302233156_add_form_builder_to_forms.rb
@@ -1,4 +1,4 @@
-class AddFormBuilderToForms < ActiveRecord::Migration[4.2]
+class AddFormBuilderToForms < ActiveRecord::Migration
   def change
     add_reference :forms, :form_builder, index: true
     add_foreign_key :forms, :form_builders

--- a/db/archived/20160302235200_create_reports.rb
+++ b/db/archived/20160302235200_create_reports.rb
@@ -1,4 +1,4 @@
-class CreateReports < ActiveRecord::Migration[4.2]
+class CreateReports < ActiveRecord::Migration
   def change
     create_table :reports do |t|
       t.string :type

--- a/db/archived/20160303011241_add_question_to_form_fields.rb
+++ b/db/archived/20160303011241_add_question_to_form_fields.rb
@@ -1,4 +1,4 @@
-class AddQuestionToFormFields < ActiveRecord::Migration[4.2]
+class AddQuestionToFormFields < ActiveRecord::Migration
   def change
     add_column :form_fields, :question, :string
   end

--- a/db/archived/20160303183603_add_fields_to_form_fields.rb
+++ b/db/archived/20160303183603_add_fields_to_form_fields.rb
@@ -1,4 +1,4 @@
-class AddFieldsToFormFields < ActiveRecord::Migration[4.2]
+class AddFieldsToFormFields < ActiveRecord::Migration
   def change
     add_column :form_fields, :status, :boolean, default: true
     add_column :form_fields, :instructional_hint, :string

--- a/db/archived/20160303192442_create_answer_options.rb
+++ b/db/archived/20160303192442_create_answer_options.rb
@@ -1,4 +1,4 @@
-class CreateAnswerOptions < ActiveRecord::Migration[4.2]
+class CreateAnswerOptions < ActiveRecord::Migration
   def change
     create_table :answer_options do |t|
       t.string :name

--- a/db/archived/20160303192945_create_form_field_answer_options.rb
+++ b/db/archived/20160303192945_create_form_field_answer_options.rb
@@ -1,4 +1,4 @@
-class CreateFormFieldAnswerOptions < ActiveRecord::Migration[4.2]
+class CreateFormFieldAnswerOptions < ActiveRecord::Migration
   def change
     create_table :form_field_answer_options do |t|
       t.references :form_field, index: true

--- a/db/archived/20160303234935_add_user_id_to_reports.rb
+++ b/db/archived/20160303234935_add_user_id_to_reports.rb
@@ -1,4 +1,4 @@
-class AddUserIdToReports < ActiveRecord::Migration[4.2]
+class AddUserIdToReports < ActiveRecord::Migration
   def change
     add_reference :reports, :user, index: true
     add_foreign_key :reports, :users

--- a/db/archived/20160303235225_add_project_id_to_reports.rb
+++ b/db/archived/20160303235225_add_project_id_to_reports.rb
@@ -1,4 +1,4 @@
-class AddProjectIdToReports < ActiveRecord::Migration[4.2]
+class AddProjectIdToReports < ActiveRecord::Migration
   def change
     add_reference :reports, :project, index: true
     add_foreign_key :reports, :projects

--- a/db/archived/20160308191711_add_date_to_reports.rb
+++ b/db/archived/20160308191711_add_date_to_reports.rb
@@ -1,4 +1,4 @@
-class AddDateToReports < ActiveRecord::Migration[4.2]
+class AddDateToReports < ActiveRecord::Migration
   def change
     add_column :reports, :date, :date
   end

--- a/db/archived/20160308211350_create_report_form_field_answers.rb
+++ b/db/archived/20160308211350_create_report_form_field_answers.rb
@@ -1,4 +1,4 @@
-class CreateReportFormFieldAnswers < ActiveRecord::Migration[4.2]
+class CreateReportFormFieldAnswers < ActiveRecord::Migration
   def change
     create_table :report_form_field_answers do |t|
       t.references :report, index: true

--- a/db/archived/20160309051807_add_answer_option_id_to_report_form_field_answers.rb
+++ b/db/archived/20160309051807_add_answer_option_id_to_report_form_field_answers.rb
@@ -1,4 +1,4 @@
-class AddAnswerOptionIdToReportFormFieldAnswers < ActiveRecord::Migration[4.2]
+class AddAnswerOptionIdToReportFormFieldAnswers < ActiveRecord::Migration
   def change
     add_reference :report_form_field_answers, :answer_option, index: true
     add_foreign_key :report_form_field_answers, :answer_options

--- a/db/archived/20160309213821_add_rating_to_reports.rb
+++ b/db/archived/20160309213821_add_rating_to_reports.rb
@@ -1,4 +1,4 @@
-class AddRatingToReports < ActiveRecord::Migration[4.2]
+class AddRatingToReports < ActiveRecord::Migration
   def change
     add_column :reports, :rating, :integer, default: 0
   end

--- a/db/archived/20160311001829_add_windows_type_to_reports.rb
+++ b/db/archived/20160311001829_add_windows_type_to_reports.rb
@@ -1,4 +1,4 @@
-class AddWindowsTypeToReports < ActiveRecord::Migration[4.2]
+class AddWindowsTypeToReports < ActiveRecord::Migration
   def change
     add_reference :reports, :windows_type, index: true
     add_foreign_key :reports, :windows_types

--- a/db/archived/20160315213952_add_description_to_form_builders.rb
+++ b/db/archived/20160315213952_add_description_to_form_builders.rb
@@ -1,4 +1,4 @@
-class AddDescriptionToFormBuilders < ActiveRecord::Migration[4.2]
+class AddDescriptionToFormBuilders < ActiveRecord::Migration
   def change
     add_column :form_builders, :description, :text
   end

--- a/db/archived/20160316230158_add_windows_type_id_to_form_builders.rb
+++ b/db/archived/20160316230158_add_windows_type_id_to_form_builders.rb
@@ -1,4 +1,4 @@
-class AddWindowsTypeIdToFormBuilders < ActiveRecord::Migration[4.2]
+class AddWindowsTypeIdToFormBuilders < ActiveRecord::Migration
   def change
     add_reference :form_builders, :windows_type, index: true
     add_foreign_key :form_builders, :windows_types

--- a/db/archived/20160322185358_add_spanish_fields_to_workshops.rb
+++ b/db/archived/20160322185358_add_spanish_fields_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddSpanishFieldsToWorkshops < ActiveRecord::Migration[4.2]
+class AddSpanishFieldsToWorkshops < ActiveRecord::Migration
   def change
     add_column :workshops, :objective_spanish, :text
     add_column :workshops, :materials_spanish, :text

--- a/db/archived/20160331134036_create_ckeditor_assets.rb
+++ b/db/archived/20160331134036_create_ckeditor_assets.rb
@@ -1,4 +1,4 @@
-class CreateCkeditorAssets < ActiveRecord::Migration[4.2]
+class CreateCkeditorAssets < ActiveRecord::Migration
   def self.up
     create_table :ckeditor_assets do |t|
       t.string  :data_file_name, null: false

--- a/db/archived/20160405191600_add_attachment_thumbnail_to_workshops.rb
+++ b/db/archived/20160405191600_add_attachment_thumbnail_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddAttachmentThumbnailToWorkshops < ActiveRecord::Migration[4.2]
+class AddAttachmentThumbnailToWorkshops < ActiveRecord::Migration
   def self.up
     change_table :workshops do |t|
       t.attachment :thumbnail

--- a/db/archived/20160405213119_create_notifications.rb
+++ b/db/archived/20160405213119_create_notifications.rb
@@ -1,4 +1,4 @@
-class CreateNotifications < ActiveRecord::Migration[4.2]
+class CreateNotifications < ActiveRecord::Migration
   def change
     create_table :notifications do |t|
       t.references :report, index: true

--- a/db/archived/20160413222912_add_extra_address_fields_to_users.rb
+++ b/db/archived/20160413222912_add_extra_address_fields_to_users.rb
@@ -1,4 +1,4 @@
-class AddExtraAddressFieldsToUsers < ActiveRecord::Migration[4.2]
+class AddExtraAddressFieldsToUsers < ActiveRecord::Migration
   def change
     add_column :users, :phone2, :string
     add_column :users, :phone3, :string

--- a/db/archived/20160414215758_add_polymorphic_fields_to_notification.rb
+++ b/db/archived/20160414215758_add_polymorphic_fields_to_notification.rb
@@ -1,4 +1,4 @@
-class AddPolymorphicFieldsToNotification < ActiveRecord::Migration[4.2]
+class AddPolymorphicFieldsToNotification < ActiveRecord::Migration
   def change
     add_column :notifications, :notification_type, :integer
     add_column :notifications, :noticeable_type, :string

--- a/db/archived/20160414220017_remove_report_id_from_notifications.rb
+++ b/db/archived/20160414220017_remove_report_id_from_notifications.rb
@@ -1,4 +1,4 @@
-class RemoveReportIdFromNotifications < ActiveRecord::Migration[4.2]
+class RemoveReportIdFromNotifications < ActiveRecord::Migration
   def up
     remove_foreign_key :notifications, :reports
     remove_column :notifications, :report_id

--- a/db/archived/20160525192953_add_new_fields_to_workshops.rb
+++ b/db/archived/20160525192953_add_new_fields_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddNewFieldsToWorkshops < ActiveRecord::Migration[4.2]
+class AddNewFieldsToWorkshops < ActiveRecord::Migration
   def change
     add_column :workshops, :optional_materials, :text
     add_column :workshops, :optional_materials_spanish, :text

--- a/db/archived/20160525212108_make_inactive_default_to_true_on_quotes.rb
+++ b/db/archived/20160525212108_make_inactive_default_to_true_on_quotes.rb
@@ -1,4 +1,4 @@
-class MakeInactiveDefaultToTrueOnQuotes < ActiveRecord::Migration[4.2]
+class MakeInactiveDefaultToTrueOnQuotes < ActiveRecord::Migration
   def up
     change_column :quotes, :inactive, :boolean, default: true
   end

--- a/db/archived/20160525213613_add_inactive_to_sectorable_items.rb
+++ b/db/archived/20160525213613_add_inactive_to_sectorable_items.rb
@@ -1,4 +1,4 @@
-class AddInactiveToSectorableItems < ActiveRecord::Migration[4.2]
+class AddInactiveToSectorableItems < ActiveRecord::Migration
   def change
     add_column :sectorable_items, :inactive, :boolean, default: true
   end

--- a/db/archived/20160525213624_add_inactive_to_categorizable_items.rb
+++ b/db/archived/20160525213624_add_inactive_to_categorizable_items.rb
@@ -1,4 +1,4 @@
-class AddInactiveToCategorizableItems < ActiveRecord::Migration[4.2]
+class AddInactiveToCategorizableItems < ActiveRecord::Migration
   def change
     add_column :categorizable_items, :inactive, :boolean, default: true
   end

--- a/db/archived/20160525213911_add_published_to_metadatum.rb
+++ b/db/archived/20160525213911_add_published_to_metadatum.rb
@@ -1,4 +1,4 @@
-class AddPublishedToMetadatum < ActiveRecord::Migration[4.2]
+class AddPublishedToMetadatum < ActiveRecord::Migration
   def change
     add_column :metadata, :published, :boolean, default: false
   end

--- a/db/archived/20160525214235_make_published_default_to_false_on_sectors.rb
+++ b/db/archived/20160525214235_make_published_default_to_false_on_sectors.rb
@@ -1,4 +1,4 @@
-class MakePublishedDefaultToFalseOnSectors < ActiveRecord::Migration[4.2]
+class MakePublishedDefaultToFalseOnSectors < ActiveRecord::Migration
   def change
     change_column :sectors, :published, :boolean, default: false
   end

--- a/db/archived/20160525214413_add_published_to_categories.rb
+++ b/db/archived/20160525214413_add_published_to_categories.rb
@@ -1,4 +1,4 @@
-class AddPublishedToCategories < ActiveRecord::Migration[4.2]
+class AddPublishedToCategories < ActiveRecord::Migration
   def change
     add_column :categories, :published, :boolean, default: false
   end

--- a/db/archived/20160612002754_add_age_to_quotes.rb
+++ b/db/archived/20160612002754_add_age_to_quotes.rb
@@ -1,4 +1,4 @@
-class AddAgeToQuotes < ActiveRecord::Migration[4.2]
+class AddAgeToQuotes < ActiveRecord::Migration
   def change
     add_column :quotes, :age, :string
   end

--- a/db/archived/20160716230954_alter_form_field_status_column.rb
+++ b/db/archived/20160716230954_alter_form_field_status_column.rb
@@ -1,4 +1,4 @@
-class AlterFormFieldStatusColumn < ActiveRecord::Migration[4.2]
+class AlterFormFieldStatusColumn < ActiveRecord::Migration
   def up
     remove_column :form_fields, :status
     add_column :form_fields, :status, :integer, default: 1

--- a/db/archived/20170503123822_add_attachment_avatar_to_users.rb
+++ b/db/archived/20170503123822_add_attachment_avatar_to_users.rb
@@ -1,4 +1,4 @@
-class AddAttachmentAvatarToUsers < ActiveRecord::Migration[4.2]
+class AddAttachmentAvatarToUsers < ActiveRecord::Migration
   def self.up
     change_table :users do |t|
       t.attachment :avatar

--- a/db/archived/20170705121520_add_gender_to_quotes.rb
+++ b/db/archived/20170705121520_add_gender_to_quotes.rb
@@ -1,4 +1,4 @@
-class AddGenderToQuotes < ActiveRecord::Migration[4.2]
+class AddGenderToQuotes < ActiveRecord::Migration
   def change
     add_column :quotes, :gender, :string, :limit => 1
   end

--- a/db/archived/20170707115021_reorder_monthly_report_fields.rb
+++ b/db/archived/20170707115021_reorder_monthly_report_fields.rb
@@ -1,4 +1,4 @@
-class ReorderMonthlyReportFields < ActiveRecord::Migration[4.2]
+class ReorderMonthlyReportFields < ActiveRecord::Migration
   def change
     questions = ["If this is a quote or story from a participant please indicate the following", "Age", "Gender Identity", "Service Population"]
 

--- a/db/archived/20170707143737_add_image_to_reports.rb
+++ b/db/archived/20170707143737_add_image_to_reports.rb
@@ -1,4 +1,4 @@
-class AddImageToReports < ActiveRecord::Migration[4.2]
+class AddImageToReports < ActiveRecord::Migration
   def change
     add_reference :images, :report, foreign_key: true
   end

--- a/db/archived/20170710153422_add_file_to_reports.rb
+++ b/db/archived/20170710153422_add_file_to_reports.rb
@@ -1,4 +1,4 @@
-class AddFileToReports < ActiveRecord::Migration[4.2]
+class AddFileToReports < ActiveRecord::Migration
   def up
     add_attachment :reports, :form_file
   end

--- a/db/archived/20170712132234_monthly_report_fields_changes.rb
+++ b/db/archived/20170712132234_monthly_report_fields_changes.rb
@@ -1,4 +1,4 @@
-class MonthlyReportFieldsChanges < ActiveRecord::Migration[4.2]
+class MonthlyReportFieldsChanges < ActiveRecord::Migration
   def change
     forms = FormBuilder.where('name LIKE ?', '%Monthly Report%')
 

--- a/db/archived/20170712165633_add_ethnicity_to_monthly_report.rb
+++ b/db/archived/20170712165633_add_ethnicity_to_monthly_report.rb
@@ -1,4 +1,4 @@
-class AddEthnicityToMonthlyReport < ActiveRecord::Migration[4.2]
+class AddEthnicityToMonthlyReport < ActiveRecord::Migration
   def change
     forms = FormBuilder.where('name LIKE ?', '%Workshop Log%')
 

--- a/db/archived/20170713134705_fix_workshop_log_fields.rb
+++ b/db/archived/20170713134705_fix_workshop_log_fields.rb
@@ -1,4 +1,4 @@
-class FixWorkshopLogFields < ActiveRecord::Migration[4.2]
+class FixWorkshopLogFields < ActiveRecord::Migration
   def change
     forms = FormBuilder.where('name LIKE ?', '%Workshop Log%')
 

--- a/db/archived/20170713141406_fix_workshop_log_field_adult_age.rb
+++ b/db/archived/20170713141406_fix_workshop_log_field_adult_age.rb
@@ -1,4 +1,4 @@
-class FixWorkshopLogFieldAdultAge < ActiveRecord::Migration[4.2]
+class FixWorkshopLogFieldAdultAge < ActiveRecord::Migration
   def change
     forms = FormBuilder.where('name LIKE ?', '%Workshop Log%')
 

--- a/db/archived/20170713150857_update_windows_type.rb
+++ b/db/archived/20170713150857_update_windows_type.rb
@@ -1,4 +1,4 @@
-class UpdateWindowsType < ActiveRecord::Migration[4.2]
+class UpdateWindowsType < ActiveRecord::Migration
   def change
     wt = WindowsType.find_by(name: "Adult Windows")
     wt.update(name: "ADULT WORKSHOP LOG")

--- a/db/archived/20170713170027_fix_gender_fields_order.rb
+++ b/db/archived/20170713170027_fix_gender_fields_order.rb
@@ -1,4 +1,4 @@
-class FixGenderFieldsOrder < ActiveRecord::Migration[4.2]
+class FixGenderFieldsOrder < ActiveRecord::Migration
   def change
     forms = FormBuilder.where('name LIKE ?', '%Workshop Log%')
 

--- a/db/archived/20170714131203_fix_ethinicity_order.rb
+++ b/db/archived/20170714131203_fix_ethinicity_order.rb
@@ -1,4 +1,4 @@
-class FixEthinicityOrder < ActiveRecord::Migration[4.2]
+class FixEthinicityOrder < ActiveRecord::Migration
   def change
     forms = FormBuilder.where('name LIKE ?', '%Workshop Log%')
 

--- a/db/archived/20170714155944_add_parent_id_to_form_fields.rb
+++ b/db/archived/20170714155944_add_parent_id_to_form_fields.rb
@@ -1,4 +1,4 @@
-class AddParentIdToFormFields < ActiveRecord::Migration[4.2]
+class AddParentIdToFormFields < ActiveRecord::Migration
   def change
     add_column :form_fields, :parent_id, :integer, references: :form_fields
   end

--- a/db/archived/20170714173609_update_ethnicity_fileds_as_childs.rb
+++ b/db/archived/20170714173609_update_ethnicity_fileds_as_childs.rb
@@ -1,4 +1,4 @@
-class UpdateEthnicityFiledsAsChilds < ActiveRecord::Migration[4.2]
+class UpdateEthnicityFiledsAsChilds < ActiveRecord::Migration
   def change
     forms = FormBuilder.where('name LIKE ?', '%Workshop Log%')
 

--- a/db/archived/20170714184157_delete_extra_gender_from_adult.rb
+++ b/db/archived/20170714184157_delete_extra_gender_from_adult.rb
@@ -1,4 +1,4 @@
-class DeleteExtraGenderFromAdult < ActiveRecord::Migration[4.2]
+class DeleteExtraGenderFromAdult < ActiveRecord::Migration
   def change
     form = FormBuilder.where('name LIKE ?', '%Adult Workshop Log%').first
     field = form.form_fields.find_by(question: "Gender",

--- a/db/archived/20170714185948_delete_extra_gender_from_adult_ok.rb
+++ b/db/archived/20170714185948_delete_extra_gender_from_adult_ok.rb
@@ -1,4 +1,4 @@
-class DeleteExtraGenderFromAdultOk < ActiveRecord::Migration[4.2]
+class DeleteExtraGenderFromAdultOk < ActiveRecord::Migration
   def change
     form = FormBuilder.where('name LIKE ?', '%Adult Workshop Log%').first
     field = form.form_fields.find_by(question: "Gender",

--- a/db/archived/20170717141411_reduce_name_to_full_name_for_workshop.rb
+++ b/db/archived/20170717141411_reduce_name_to_full_name_for_workshop.rb
@@ -1,4 +1,4 @@
-class ReduceNameToFullNameForWorkshop < ActiveRecord::Migration[4.2]
+class ReduceNameToFullNameForWorkshop < ActiveRecord::Migration
   def change
     Workshop.find_each do |w|
       w.update(author_first_name: "#{w.author_first_name} #{w.author_last_name}")

--- a/db/archived/20170818134550_change_required_to_monthly_report_fields.rb
+++ b/db/archived/20170818134550_change_required_to_monthly_report_fields.rb
@@ -1,4 +1,4 @@
-class ChangeRequiredToMonthlyReportFields < ActiveRecord::Migration[4.2]
+class ChangeRequiredToMonthlyReportFields < ActiveRecord::Migration
   def change
     questions = ["Share challenges for this month",
                  "Share a highlight for this month",

--- a/db/archived/20170818174627_change_required_challenge_to_monthly_report_field.rb
+++ b/db/archived/20170818174627_change_required_challenge_to_monthly_report_field.rb
@@ -1,4 +1,4 @@
-class ChangeRequiredChallengeToMonthlyReportField < ActiveRecord::Migration[4.2]
+class ChangeRequiredChallengeToMonthlyReportField < ActiveRecord::Migration
   def change
     forms = FormBuilder.where('name LIKE ?', '%Monthly Report%')
 

--- a/db/archived/20170825171714_set_workshop_log_required_fields.rb
+++ b/db/archived/20170825171714_set_workshop_log_required_fields.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-class SetWorkshopLogRequiredFields < ActiveRecord::Migration[4.2]
+class SetWorkshopLogRequiredFields < ActiveRecord::Migration
     def change
       questions = ["Total # On-going Participants",
                    "Total # First-Time Participants",

--- a/db/archived/20170828174841_update_ethnicity_hint_to_monthly_report.rb
+++ b/db/archived/20170828174841_update_ethnicity_hint_to_monthly_report.rb
@@ -1,4 +1,4 @@
-class UpdateEthnicityHintToMonthlyReport < ActiveRecord::Migration[4.2]
+class UpdateEthnicityHintToMonthlyReport < ActiveRecord::Migration
   def change
     forms = FormBuilder.where('name LIKE ?', '%Workshop Log%')
 

--- a/db/archived/20170829142848_ethnicity_non_as_required.rb
+++ b/db/archived/20170829142848_ethnicity_non_as_required.rb
@@ -1,4 +1,4 @@
-class EthnicityNonAsRequired < ActiveRecord::Migration[4.2]
+class EthnicityNonAsRequired < ActiveRecord::Migration
   def change
     forms = FormBuilder.where('name LIKE ?', '%Workshop Log%')
 

--- a/db/archived/20170914132342_create_footers.rb
+++ b/db/archived/20170914132342_create_footers.rb
@@ -1,4 +1,4 @@
-class CreateFooters < ActiveRecord::Migration[4.2]
+class CreateFooters < ActiveRecord::Migration
   def change
     create_table :footers do |t|
       t.string :phone

--- a/db/archived/20171002120848_add_fulltext_search_workshops.rb
+++ b/db/archived/20171002120848_add_fulltext_search_workshops.rb
@@ -1,4 +1,4 @@
-class AddFulltextSearchWorkshops < ActiveRecord::Migration[4.2]
+class AddFulltextSearchWorkshops < ActiveRecord::Migration
   def change
     add_index :workshops, [:title, :objective, :materials, :introduction, :demonstration, :opening_circle, :warm_up, :creation, :closing, :notes, :tips, :misc1, :misc2], name: 'workshop_fullsearch', type: :fulltext
   end

--- a/db/archived/20171002171856_migrate_resource_types.rb
+++ b/db/archived/20171002171856_migrate_resource_types.rb
@@ -1,4 +1,4 @@
-class MigrateResourceTypes < ActiveRecord::Migration[4.2]
+class MigrateResourceTypes < ActiveRecord::Migration
   def change
     Resource.where(type: "TemplateAndHandout").update_all(type: "Template")
     Resource.where(type: "ToolkitAndForm").update_all(type: "Form")

--- a/db/archived/20171002174656_change_resource_type_column.rb
+++ b/db/archived/20171002174656_change_resource_type_column.rb
@@ -1,4 +1,4 @@
-class ChangeResourceTypeColumn < ActiveRecord::Migration[4.2]
+class ChangeResourceTypeColumn < ActiveRecord::Migration
   def change
     rename_column :resources, :type, :kind
   end

--- a/db/archived/20171005142611_add_fulltext_search_title_to_workshops.rb
+++ b/db/archived/20171005142611_add_fulltext_search_title_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddFulltextSearchTitleToWorkshops < ActiveRecord::Migration[4.2]
+class AddFulltextSearchTitleToWorkshops < ActiveRecord::Migration
   def change
     add_index :workshops, [:title], name: 'workshop_fullsearch_title', type: :fulltext
   end

--- a/db/archived/20171018145108_create_user_for_orphaned_reports.rb
+++ b/db/archived/20171018145108_create_user_for_orphaned_reports.rb
@@ -1,4 +1,4 @@
-class CreateUserForOrphanedReports < ActiveRecord::Migration[4.2]
+class CreateUserForOrphanedReports < ActiveRecord::Migration
   def up
     user = User.new(first_name: "Orphaned", last_name: "Reports", email: "orphaned_reports@awbw.org", password: "awbworphaned")
     user.save!

--- a/db/archived/20171020140722_change_fields_ordering_combined_workshop_log.rb
+++ b/db/archived/20171020140722_change_fields_ordering_combined_workshop_log.rb
@@ -1,4 +1,4 @@
-class ChangeFieldsOrderingCombinedWorkshopLog < ActiveRecord::Migration[4.2]
+class ChangeFieldsOrderingCombinedWorkshopLog < ActiveRecord::Migration
   def change
     form = FormBuilder.where('name LIKE ?', '%Family Workshop Log%').first
 

--- a/db/archived/20171023125218_add_combined_perms_to_existing_users.rb
+++ b/db/archived/20171023125218_add_combined_perms_to_existing_users.rb
@@ -1,4 +1,4 @@
-class AddCombinedPermsToExistingUsers < ActiveRecord::Migration[4.2]
+class AddCombinedPermsToExistingUsers < ActiveRecord::Migration
   def change
     User.find_in_batches do |group|
       group.each do |user|

--- a/db/archived/20171103134801_delete_workshop_name_to_share_a_story.rb
+++ b/db/archived/20171103134801_delete_workshop_name_to_share_a_story.rb
@@ -1,4 +1,4 @@
-class DeleteWorkshopNameToShareAStory < ActiveRecord::Migration[4.2]
+class DeleteWorkshopNameToShareAStory < ActiveRecord::Migration
   def change
     form = FormBuilder.find_by(name: "Share a Story")
     field = form.form_fields.find_by(question: "Workshop Name")

--- a/db/archived/20171106180556_set_share_story_ordering_fields.rb
+++ b/db/archived/20171106180556_set_share_story_ordering_fields.rb
@@ -1,4 +1,4 @@
-class SetShareStoryOrderingFields < ActiveRecord::Migration[4.2]
+class SetShareStoryOrderingFields < ActiveRecord::Migration
   def change
     form = FormBuilder.find_by(name: 'Share a Story')
 

--- a/db/archived/20171107130510_add_workshop_id_to_report.rb
+++ b/db/archived/20171107130510_add_workshop_id_to_report.rb
@@ -1,4 +1,4 @@
-class AddWorkshopIdToReport < ActiveRecord::Migration[4.2]
+class AddWorkshopIdToReport < ActiveRecord::Migration
   def change
     add_column :reports, :workshop_id, :integer
   end

--- a/db/archived/20171109130612_fix_user_perms.rb
+++ b/db/archived/20171109130612_fix_user_perms.rb
@@ -1,4 +1,4 @@
-class FixUserPerms < ActiveRecord::Migration[4.2]
+class FixUserPerms < ActiveRecord::Migration
   def change
     UserPermission.delete_all
     Permission.delete_all

--- a/db/archived/20171114134457_add_fields_time_frame_to_workshops.rb
+++ b/db/archived/20171114134457_add_fields_time_frame_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddFieldsTimeFrameToWorkshops < ActiveRecord::Migration[4.2]
+class AddFieldsTimeFrameToWorkshops < ActiveRecord::Migration
   def change
     add_column :workshops, :time_intro, :integer
     add_column :workshops, :time_demonstration, :integer

--- a/db/archived/20171206190101_give_all_users_full_perms.rb
+++ b/db/archived/20171206190101_give_all_users_full_perms.rb
@@ -1,4 +1,4 @@
-class GiveAllUsersFullPerms < ActiveRecord::Migration[4.2]
+class GiveAllUsersFullPerms < ActiveRecord::Migration
   def change
     puts
 

--- a/db/archived/20180109124525_fix_emtpy_colon_time_frame_workshop.rb
+++ b/db/archived/20180109124525_fix_emtpy_colon_time_frame_workshop.rb
@@ -1,4 +1,4 @@
-class FixEmtpyColonTimeFrameWorkshop < ActiveRecord::Migration[4.2]
+class FixEmtpyColonTimeFrameWorkshop < ActiveRecord::Migration
   def change
     Workshop.where(timeframe: ":").update_all(timeframe: nil)
   end

--- a/db/archived/20180305141651_add_field_time_frame_opening_to_workshops.rb
+++ b/db/archived/20180305141651_add_field_time_frame_opening_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddFieldTimeFrameOpeningToWorkshops < ActiveRecord::Migration[4.2]
+class AddFieldTimeFrameOpeningToWorkshops < ActiveRecord::Migration
   def change
      add_column :workshops, :time_opening, :integer
   end

--- a/db/archived/20180423132503_add_actual_url_to_ckeditor_assets.rb
+++ b/db/archived/20180423132503_add_actual_url_to_ckeditor_assets.rb
@@ -1,4 +1,4 @@
-class AddActualUrlToCkeditorAssets < ActiveRecord::Migration[4.2]
+class AddActualUrlToCkeditorAssets < ActiveRecord::Migration
   def change
     add_column :ckeditor_assets, :actual_url, :string
   end

--- a/db/archived/20180424171545_add_speaker_name_to_quotes.rb
+++ b/db/archived/20180424171545_add_speaker_name_to_quotes.rb
@@ -1,4 +1,4 @@
-class AddSpeakerNameToQuotes < ActiveRecord::Migration[4.2]
+class AddSpeakerNameToQuotes < ActiveRecord::Migration
   def change
     add_column :quotes, :speaker_name, :string
   end

--- a/db/archived/20180508135248_delete_extra_gender_identity_adult_to_workshop_log.rb
+++ b/db/archived/20180508135248_delete_extra_gender_identity_adult_to_workshop_log.rb
@@ -1,4 +1,4 @@
-class DeleteExtraGenderIdentityAdultToWorkshopLog < ActiveRecord::Migration[4.2]
+class DeleteExtraGenderIdentityAdultToWorkshopLog < ActiveRecord::Migration
   def change
     form = FormBuilder.where('name LIKE ?', '%Adult Workshop Log%').first
     field = form.form_fields.find_by(question: "Gender Identity",

--- a/db/archived/20180508154054_change_fields_ordering_to_combined_workshop_log.rb
+++ b/db/archived/20180508154054_change_fields_ordering_to_combined_workshop_log.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-class ChangeFieldsOrderingToCombinedWorkshopLog < ActiveRecord::Migration[4.2]
+class ChangeFieldsOrderingToCombinedWorkshopLog < ActiveRecord::Migration
   def change
     form = FormBuilder.where('name LIKE ?', '%Family Workshop Log%').first
 

--- a/db/archived/20180509123906_delete_extra_date_field_workshop_logs.rb
+++ b/db/archived/20180509123906_delete_extra_date_field_workshop_logs.rb
@@ -1,4 +1,4 @@
-class DeleteExtraDateFieldWorkshopLogs < ActiveRecord::Migration[4.2]
+class DeleteExtraDateFieldWorkshopLogs < ActiveRecord::Migration
   def change
     form = FormBuilder.where('name LIKE ?', '%Family Workshop Log%').first
     field = form.form_fields.find_by(question: "Workshop Date")

--- a/db/archived/20180522183329_change_text_gender_identity.rb
+++ b/db/archived/20180522183329_change_text_gender_identity.rb
@@ -1,4 +1,4 @@
-class ChangeTextGenderIdentity < ActiveRecord::Migration[4.2]
+class ChangeTextGenderIdentity < ActiveRecord::Migration
   def change
     form = FormBuilder.where('name LIKE ?', '%Family Workshop Log%').first
     field = form.form_fields.find_by(question: "Gender Identity")

--- a/db/archived/20180522203307_inactive_workshop_led_field_to_combined_log.rb
+++ b/db/archived/20180522203307_inactive_workshop_led_field_to_combined_log.rb
@@ -1,4 +1,4 @@
-class InactiveWorkshopLedFieldToCombinedLog < ActiveRecord::Migration[4.2]
+class InactiveWorkshopLedFieldToCombinedLog < ActiveRecord::Migration
   def change
     form = FormBuilder.where('name LIKE ?', '%Family Workshop Log%').first
     field = form.form_fields.find_by(question: "Workshop Led")

--- a/db/archived/20180606192110_add_workshop_name_to_workshop_logs.rb
+++ b/db/archived/20180606192110_add_workshop_name_to_workshop_logs.rb
@@ -1,4 +1,4 @@
-class AddWorkshopNameToWorkshopLogs < ActiveRecord::Migration[4.2]
+class AddWorkshopNameToWorkshopLogs < ActiveRecord::Migration
   def change
     add_column :reports, :workshop_name, :string
   end

--- a/db/archived/20180628143626_other_description_to_workshop_logs.rb
+++ b/db/archived/20180628143626_other_description_to_workshop_logs.rb
@@ -1,4 +1,4 @@
-class OtherDescriptionToWorkshopLogs < ActiveRecord::Migration[4.2]
+class OtherDescriptionToWorkshopLogs < ActiveRecord::Migration
   def change
     add_column :reports, :other_description, :string
   end

--- a/db/archived/20180628181841_delete_ethnicity_to_workshop_log.rb
+++ b/db/archived/20180628181841_delete_ethnicity_to_workshop_log.rb
@@ -1,4 +1,4 @@
-class DeleteEthnicityToWorkshopLog < ActiveRecord::Migration[4.2]
+class DeleteEthnicityToWorkshopLog < ActiveRecord::Migration
   def change
     forms = FormBuilder.where('name LIKE ?', '%Workshop Log%')
     forms.each do |f|

--- a/db/archived/20180813125338_fix_share_story_owner_type.rb
+++ b/db/archived/20180813125338_fix_share_story_owner_type.rb
@@ -1,4 +1,4 @@
-class FixShareStoryOwnerType < ActiveRecord::Migration[4.2]
+class FixShareStoryOwnerType < ActiveRecord::Migration
   def up
     @reports = Report.where(owner_type: "Report", owner_id: 7)
     @reports.update_all(owner_type: "FormBuilder")

--- a/db/archived/20180817134310_add_header_image_to_workshops.rb
+++ b/db/archived/20180817134310_add_header_image_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddHeaderImageToWorkshops < ActiveRecord::Migration[4.2]
+class AddHeaderImageToWorkshops < ActiveRecord::Migration
   def up
     add_attachment :workshops, :header
   end

--- a/db/archived/20180821130355_add_extra_field_to_workshops.rb
+++ b/db/archived/20180821130355_add_extra_field_to_workshops.rb
@@ -1,5 +1,5 @@
 # coding: utf-8
-class AddExtraFieldToWorkshops < ActiveRecord::Migration[4.2]
+class AddExtraFieldToWorkshops < ActiveRecord::Migration
   def change
     add_column :workshops, :extra_field, :string
     add_column :workshops, :extra_field_spanish, :string

--- a/db/archived/20180821133634_user_inactive_change_default.rb
+++ b/db/archived/20180821133634_user_inactive_change_default.rb
@@ -1,4 +1,4 @@
-class UserInactiveChangeDefault < ActiveRecord::Migration[4.2]
+class UserInactiveChangeDefault < ActiveRecord::Migration
   def change
     change_column_default(:users, :inactive, false)
   end

--- a/db/archived/20180821134140_user_confirmed_change_default.rb
+++ b/db/archived/20180821134140_user_confirmed_change_default.rb
@@ -1,4 +1,4 @@
-class UserConfirmedChangeDefault < ActiveRecord::Migration[4.2]
+class UserConfirmedChangeDefault < ActiveRecord::Migration
   def change
     change_column_default(:users, :confirmed, true)
   end

--- a/db/archived/20180829124317_add_super_user_to_users.rb
+++ b/db/archived/20180829124317_add_super_user_to_users.rb
@@ -1,4 +1,4 @@
-class AddSuperUserToUsers < ActiveRecord::Migration[4.2]
+class AddSuperUserToUsers < ActiveRecord::Migration
   def change
     add_column :users, :super_user, :boolean, default: false
   end

--- a/db/archived/20180911110829_change_extra_field_data_type.rb
+++ b/db/archived/20180911110829_change_extra_field_data_type.rb
@@ -1,4 +1,4 @@
-class ChangeExtraFieldDataType < ActiveRecord::Migration[4.2]
+class ChangeExtraFieldDataType < ActiveRecord::Migration
   def self.up
     change_column :workshops, :extra_field, :text
     change_column :workshops, :extra_field_spanish, :text

--- a/db/archived/20181005122514_create_media_files.rb
+++ b/db/archived/20181005122514_create_media_files.rb
@@ -1,4 +1,4 @@
-class CreateMediaFiles < ActiveRecord::Migration[4.2]
+class CreateMediaFiles < ActiveRecord::Migration
   def change
     create_table :media_files do |t|
       t.attachment :file

--- a/db/archived/20181009120253_add_short_name_to_windows_types.rb
+++ b/db/archived/20181009120253_add_short_name_to_windows_types.rb
@@ -1,4 +1,4 @@
-class AddShortNameToWindowsTypes < ActiveRecord::Migration[4.2]
+class AddShortNameToWindowsTypes < ActiveRecord::Migration
   def change
     add_column :windows_types, :short_name, :string
   end

--- a/db/archived/20181009121059_fill_short_name_to_windows_types.rb
+++ b/db/archived/20181009121059_fill_short_name_to_windows_types.rb
@@ -1,4 +1,4 @@
-class FillShortNameToWindowsTypes < ActiveRecord::Migration[4.2]
+class FillShortNameToWindowsTypes < ActiveRecord::Migration
   def change
     WindowsType.all.each do |w|
       if w.name.include? 'COMBINED'

--- a/db/archived/20181018145944_add_column_attach_for_reports.rb
+++ b/db/archived/20181018145944_add_column_attach_for_reports.rb
@@ -1,4 +1,4 @@
-class AddColumnAttachForReports < ActiveRecord::Migration[4.2]
+class AddColumnAttachForReports < ActiveRecord::Migration
   def change
     add_column :reports, :has_attachment, :boolean, default: false
   end

--- a/db/archived/20181022161907_set_has_attachment_monthly_reports.rb
+++ b/db/archived/20181022161907_set_has_attachment_monthly_reports.rb
@@ -1,4 +1,4 @@
-class SetHasAttachmentMonthlyReports < ActiveRecord::Migration[4.2]
+class SetHasAttachmentMonthlyReports < ActiveRecord::Migration
   def change
     MonthlyReport.find_each do |mr|
       mr.send :set_has_attachament

--- a/db/archived/20181217155110_update_type_in_story_reports.rb
+++ b/db/archived/20181217155110_update_type_in_story_reports.rb
@@ -1,4 +1,4 @@
-class UpdateTypeInStoryReports < ActiveRecord::Migration[4.2]
+class UpdateTypeInStoryReports < ActiveRecord::Migration
   def self.up
     Report.where("owner_id = 7 AND type = 'Report'").update_all(type: "Story")
   end

--- a/db/archived/20190411141807_create_banners.rb
+++ b/db/archived/20190411141807_create_banners.rb
@@ -1,4 +1,4 @@
-class CreateBanners < ActiveRecord::Migration[4.2]
+class CreateBanners < ActiveRecord::Migration
   def change
     create_table :banners do |t|
       t.text :content

--- a/db/archived/20201117045945_add_participants_to_reports.rb
+++ b/db/archived/20201117045945_add_participants_to_reports.rb
@@ -1,4 +1,4 @@
-class AddParticipantsToReports < ActiveRecord::Migration[4.2]
+class AddParticipantsToReports < ActiveRecord::Migration
   def change
     add_column :reports, :children_first_time, :integer, :default => 0
     add_column :reports, :children_ongoing, :integer, :default => 0

--- a/db/archived/20201220212228_add_workshop_log_id_to_media_files.rb
+++ b/db/archived/20201220212228_add_workshop_log_id_to_media_files.rb
@@ -1,4 +1,4 @@
-class AddWorkshopLogIdToMediaFiles < ActiveRecord::Migration[4.2]
+class AddWorkshopLogIdToMediaFiles < ActiveRecord::Migration
   def change
     add_column :media_files, :workshop_log_id, :integer
   end

--- a/db/archived/20210823001213_add_fulltext_search_full_name_to_workshops.rb
+++ b/db/archived/20210823001213_add_fulltext_search_full_name_to_workshops.rb
@@ -1,4 +1,4 @@
-class AddFulltextSearchFullNameToWorkshops < ActiveRecord::Migration[4.2]
+class AddFulltextSearchFullNameToWorkshops < ActiveRecord::Migration
   def change
     remove_index :workshops, name: 'workshop_fullsearch'
     add_index :workshops, [:title, :full_name, :objective, :materials, :introduction, :demonstration, :opening_circle, :warm_up, :creation, :closing, :notes, :tips, :misc1, :misc2], name: 'workshop_fullsearch', type: :fulltext

--- a/db/migrate/20250407002246_create_database.rb
+++ b/db/migrate/20250407002246_create_database.rb
@@ -45,26 +45,26 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.string   "name",            limit: 255
       t.datetime "created_at",                  null: false
       t.datetime "updated_at",                  null: false
-      t.bigint   "windows_type_id"
+      t.integer  "windows_type_id", limit: 4
     end
   
     add_index "age_ranges", ["windows_type_id"], name: "index_age_ranges_on_windows_type_id", using: :btree
   
     create_table "answer_options", force: :cascade do |t|
       t.string   "name",       limit: 255
-      t.integer  "order", limit: 4
+      t.integer  "order",      limit: 4
       t.datetime "created_at",             null: false
       t.datetime "updated_at",             null: false
     end
   
     create_table "attachments", force: :cascade do |t|
-      t.bigint   "owner_id"
+      t.integer  "owner_id",          limit: 4
       t.string   "owner_type",        limit: 255
       t.datetime "created_at",                    null: false
       t.datetime "updated_at",                    null: false
       t.string   "file_file_name",    limit: 255
       t.string   "file_content_type", limit: 255
-      t.bigint   "file_file_size"
+      t.integer  "file_file_size",    limit: 4
       t.datetime "file_updated_at"
     end
   
@@ -76,7 +76,7 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     end
   
     create_table "bookmark_annotations", force: :cascade do |t|
-      t.bigint   "bookmark_id"
+      t.integer  "bookmark_id", limit: 4
       t.text     "annotation",  limit: 16777215
       t.datetime "created_at",                   null: false
       t.datetime "updated_at",                   null: false
@@ -85,9 +85,9 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     add_index "bookmark_annotations", ["bookmark_id"], name: "index_bookmark_annotations_on_bookmark_id", using: :btree
   
     create_table "bookmarks", force: :cascade do |t|
-      t.bigint   "user_id"
+      t.integer  "user_id",           limit: 4
       t.string   "bookmarkable_type", limit: 255
-      t.bigint   "bookmarkable_id"
+      t.integer  "bookmarkable_id",   limit: 4
       t.datetime "created_at",                    null: false
       t.datetime "updated_at",                    null: false
     end
@@ -95,9 +95,9 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     add_index "bookmarks", ["user_id"], name: "index_bookmarks_on_user_id", using: :btree
   
     create_table "categories", force: :cascade do |t|
-      t.bigint   "metadatum_id"
+      t.integer  "metadatum_id", limit: 4
       t.string   "name",         limit: 255
-      t.bigint   "legacy_id"
+      t.integer  "legacy_id",    limit: 4
       t.datetime "created_at",                               null: false
       t.datetime "updated_at",                               null: false
       t.boolean  "published",                default: false
@@ -106,10 +106,10 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     add_index "categories", ["metadatum_id"], name: "index_categories_on_metadatum_id", using: :btree
   
     create_table "categorizable_items", force: :cascade do |t|
-      t.bigint   "categorizable_id"
+      t.integer  "categorizable_id",   limit: 4
       t.string   "categorizable_type", limit: 255
-      t.bigint   "category_id"
-      t.bigint   "legacy_id"
+      t.integer  "category_id",        limit: 4
+      t.integer  "legacy_id",          limit: 4
       t.datetime "created_at",                                    null: false
       t.datetime "updated_at",                                    null: false
       t.boolean  "inactive",                       default: true
@@ -120,12 +120,12 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     create_table "ckeditor_assets", force: :cascade do |t|
       t.string   "data_file_name",    limit: 255, null: false
       t.string   "data_content_type", limit: 255
-      t.bigint   "data_file_size"
-      t.bigint   "assetable_id"
+      t.integer  "data_file_size",    limit: 4
+      t.integer  "assetable_id",      limit: 4
       t.string   "assetable_type",    limit: 30
       t.string   "type",              limit: 30
-      t.integer  "width", limit: 4
-      t.integer  "height", limit: 4
+      t.integer  "width",             limit: 4
+      t.integer  "height",            limit: 4
       t.datetime "created_at",                    null: false
       t.datetime "updated_at",                    null: false
       t.string   "actual_url",        limit: 255
@@ -140,7 +140,7 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.datetime "created_at",                  null: false
       t.datetime "updated_at",                  null: false
       t.boolean  "inactive"
-      t.integer  "ordering", limit: 4
+      t.integer  "ordering",   limit: 4
     end
   
     create_table "footers", force: :cascade do |t|
@@ -154,18 +154,18 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
   
     create_table "form_builders", force: :cascade do |t|
       t.string   "name",            limit: 255
-      t.integer  "owner_type", limit: 4
+      t.integer  "owner_type",      limit: 4
       t.datetime "created_at",                       null: false
       t.datetime "updated_at",                       null: false
       t.text     "description",     limit: 16777215
-      t.bigint   "windows_type_id"
+      t.integer  "windows_type_id", limit: 4
     end
   
     add_index "form_builders", ["windows_type_id"], name: "index_form_builders_on_windows_type_id", using: :btree
   
     create_table "form_field_answer_options", force: :cascade do |t|
-      t.bigint   "form_field_id"
-      t.bigint   "answer_option_id"
+      t.integer  "form_field_id",    limit: 4
+      t.integer  "answer_option_id", limit: 4
       t.datetime "created_at",                 null: false
       t.datetime "updated_at",                 null: false
     end
@@ -174,41 +174,41 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     add_index "form_field_answer_options", ["form_field_id"], name: "index_form_field_answer_options_on_form_field_id", using: :btree
   
     create_table "form_fields", force: :cascade do |t|
-      t.bigint   "form_id"
+      t.integer  "form_id",            limit: 4
       t.datetime "created_at",                                    null: false
       t.datetime "updated_at",                                    null: false
       t.string   "question",           limit: 255
       t.string   "instructional_hint", limit: 255
-      t.integer  "answer_type", limit: 4
-      t.integer  "answer_datatype", limit: 4
-      t.integer  "ordering", limit: 4
+      t.integer  "answer_type",        limit: 4
+      t.integer  "answer_datatype",    limit: 4
+      t.integer  "ordering",           limit: 4
       t.boolean  "is_required",                    default: true
       t.integer  "status",             limit: 4,   default: 1
-      t.bigint   "parent_id"
+      t.integer  "parent_id",          limit: 4
     end
   
     add_index "form_fields", ["form_id"], name: "index_form_fields_on_form_id", using: :btree
   
     create_table "forms", force: :cascade do |t|
       t.string   "owner_type",      limit: 255
-      t.bigint   "owner_id"
+      t.integer  "owner_id",        limit: 4
       t.datetime "created_at",                  null: false
       t.datetime "updated_at",                  null: false
-      t.bigint   "form_builder_id"
+      t.integer  "form_builder_id", limit: 4
     end
   
     add_index "forms", ["form_builder_id"], name: "index_forms_on_form_builder_id", using: :btree
   
     create_table "images", force: :cascade do |t|
-      t.bigint   "owner_id"
+      t.integer  "owner_id",          limit: 4
       t.string   "owner_type",        limit: 255
       t.datetime "created_at",                    null: false
       t.datetime "updated_at",                    null: false
       t.string   "file_file_name",    limit: 255
       t.string   "file_content_type", limit: 255
-      t.bigint   "file_file_size"
+      t.integer  "file_file_size",    limit: 4
       t.datetime "file_updated_at"
-      t.bigint   "report_id"
+      t.integer  "report_id",         limit: 4
     end
   
     add_index "images", ["owner_id"], name: "index_images_on_owner_id", using: :btree
@@ -224,10 +224,10 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     create_table "media_files", force: :cascade do |t|
       t.string   "file_file_name",    limit: 255
       t.string   "file_content_type", limit: 255
-      t.bigint   "file_file_size"
+      t.integer  "file_file_size",    limit: 4
       t.datetime "file_updated_at"
-      t.bigint   "report_id"
-      t.bigint   "workshop_log_id"
+      t.integer  "report_id",         limit: 4
+      t.integer  "workshop_log_id",   limit: 4
     end
   
     create_table "metadata", force: :cascade do |t|
@@ -240,8 +240,8 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
   
     create_table "monthly_reports", force: :cascade do |t|
       t.string   "month",                    limit: 255
-      t.bigint   "project_id"
-      t.bigint   "project_user_id"
+      t.integer  "project_id",               limit: 4
+      t.integer  "project_user_id",          limit: 4
       t.string   "name",                     limit: 255
       t.string   "position",                 limit: 255
       t.boolean  "mail_evaluations"
@@ -267,14 +267,14 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.datetime "updated_at",                    null: false
       t.integer  "notification_type", limit: 4
       t.string   "noticeable_type",   limit: 255
-      t.bigint   "noticeable_id"
+      t.integer  "noticeable_id",     limit: 4
     end
   
     create_table "permissions", force: :cascade do |t|
       t.string   "security_cat", limit: 255
       t.datetime "created_at",               null: false
       t.datetime "updated_at",               null: false
-      t.bigint   "legacy_id"
+      t.integer  "legacy_id",    limit: 4
     end
   
     create_table "project_obligations", force: :cascade do |t|
@@ -290,12 +290,12 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     end
   
     create_table "project_users", force: :cascade do |t|
-      t.bigint   "agency_id"
-      t.bigint   "user_id"
-      t.integer  "position", limit: 4
+      t.integer  "agency_id",      limit: 4
+      t.integer  "user_id",        limit: 4
+      t.integer  "position",       limit: 4
       t.datetime "created_at",                 null: false
       t.datetime "updated_at",                 null: false
-      t.bigint   "project_id"
+      t.integer  "project_id",     limit: 4
       t.string   "filemaker_code", limit: 255
     end
   
@@ -305,10 +305,10 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
   
     create_table "projects", force: :cascade do |t|
       t.string   "name",              limit: 255
-      t.bigint   "location_id"
+      t.integer  "location_id",       limit: 4
       t.datetime "created_at",                                         null: false
       t.datetime "updated_at",                                         null: false
-      t.bigint   "windows_type_id"
+      t.integer  "windows_type_id",   limit: 4
       t.string   "district",          limit: 255
       t.date     "start_date"
       t.date     "end_date"
@@ -317,9 +317,9 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.text     "notes",             limit: 16777215
       t.string   "filemaker_code",    limit: 255
       t.boolean  "inactive",                           default: false
-      t.bigint   "legacy_id"
+      t.integer  "legacy_id",         limit: 4
       t.boolean  "legacy",                             default: false
-      t.bigint   "project_status_id"
+      t.integer  "project_status_id", limit: 4
     end
   
     add_index "projects", ["location_id"], name: "index_projects_on_location_id", using: :btree
@@ -328,9 +328,9 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
   
     create_table "quotable_item_quotes", force: :cascade do |t|
       t.string   "quotable_type", limit: 255
-      t.bigint   "quotable_id"
-      t.bigint   "legacy_id"
-      t.bigint   "quote_id"
+      t.integer  "quotable_id",   limit: 4
+      t.integer  "legacy_id",     limit: 4
+      t.integer  "quote_id",      limit: 4
       t.datetime "created_at",                null: false
       t.datetime "updated_at",                null: false
     end
@@ -340,11 +340,11 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     create_table "quotes", force: :cascade do |t|
       t.text     "quote",        limit: 16777215
       t.boolean  "inactive",                      default: true
-      t.bigint   "legacy_id"
+      t.integer  "legacy_id",    limit: 4
       t.boolean  "legacy",                        default: false
       t.datetime "created_at",                                    null: false
       t.datetime "updated_at",                                    null: false
-      t.bigint   "workshop_id"
+      t.integer  "workshop_id",  limit: 4
       t.string   "age",          limit: 255
       t.string   "gender",       limit: 1
       t.string   "speaker_name", limit: 255
@@ -353,12 +353,12 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     add_index "quotes", ["workshop_id"], name: "index_quotes_on_workshop_id", using: :btree
   
     create_table "report_form_field_answers", force: :cascade do |t|
-      t.bigint   "report_id"
-      t.bigint   "form_field_id"
+      t.integer  "report_id",        limit: 4
+      t.integer  "form_field_id",    limit: 4
       t.text     "answer",           limit: 16777215
       t.datetime "created_at"
       t.datetime "updated_at"
-      t.bigint   "answer_option_id"
+      t.integer  "answer_option_id", limit: 4
     end
   
     add_index "report_form_field_answers", ["answer_option_id"], name: "index_report_form_field_answers_on_answer_option_id", using: :btree
@@ -367,20 +367,20 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
   
     create_table "reports", force: :cascade do |t|
       t.string   "type",                   limit: 255
-      t.bigint   "owner_id"
+      t.integer  "owner_id",               limit: 4
       t.string   "owner_type",             limit: 255
       t.datetime "created_at",                                         null: false
       t.datetime "updated_at",                                         null: false
-      t.bigint   "user_id"
-      t.bigint   "project_id"
+      t.integer  "user_id",                limit: 4
+      t.integer  "project_id",             limit: 4
       t.date     "date"
       t.integer  "rating",                 limit: 4,   default: 0
-      t.bigint   "windows_type_id"
+      t.integer  "windows_type_id",        limit: 4
       t.string   "form_file_file_name",    limit: 255
       t.string   "form_file_content_type", limit: 255
-      t.bigint   "form_file_file_size"
+      t.integer  "form_file_file_size",    limit: 4
       t.datetime "form_file_updated_at"
-      t.bigint   "workshop_id"
+      t.integer  "workshop_id",            limit: 4
       t.string   "workshop_name",          limit: 255
       t.string   "other_description",      limit: 255
       t.boolean  "has_attachment",                     default: false
@@ -399,23 +399,23 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     create_table "resources", force: :cascade do |t|
       t.string   "title",           limit: 255
       t.string   "author",          limit: 255
-      t.bigint   "user_id"
+      t.integer  "user_id",         limit: 4
       t.text     "text",            limit: 16777215
       t.boolean  "featured",                         default: false
       t.datetime "created_at",                                       null: false
       t.datetime "updated_at",                                       null: false
       t.string   "kind",            limit: 255
-      t.bigint   "workshop_id"
+      t.integer  "workshop_id",     limit: 4
       t.boolean  "male",                             default: false
       t.boolean  "female",                           default: false
       t.string   "url",             limit: 255
       t.boolean  "inactive",                         default: true
       t.string   "agency",          limit: 255
       t.boolean  "legacy"
-      t.bigint   "windows_type_id"
+      t.integer  "windows_type_id", limit: 4
       t.string   "filemaker_code",  limit: 255
-      t.integer  "ordering", limit: 4
-      t.bigint   "legacy_id"
+      t.integer  "ordering",        limit: 4
+      t.integer  "legacy_id",       limit: 4
     end
   
     add_index "resources", ["user_id"], name: "index_resources_on_user_id", using: :btree
@@ -423,9 +423,9 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     add_index "resources", ["workshop_id"], name: "index_resources_on_workshop_id", using: :btree
   
     create_table "sectorable_items", force: :cascade do |t|
-      t.bigint   "sectorable_id"
+      t.integer  "sectorable_id",   limit: 4
       t.string   "sectorable_type", limit: 255
-      t.bigint   "sector_id"
+      t.integer  "sector_id",       limit: 4
       t.datetime "created_at",                                 null: false
       t.datetime "updated_at",                                 null: false
       t.boolean  "inactive",                    default: true
@@ -441,8 +441,8 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     end
   
     create_table "user_form_form_fields", force: :cascade do |t|
-      t.bigint   "form_field_id"
-      t.bigint   "user_form_id"
+      t.integer  "form_field_id", limit: 4
+      t.integer  "user_form_id",  limit: 4
       t.text     "text",          limit: 16777215
       t.datetime "created_at",                     null: false
       t.datetime "updated_at",                     null: false
@@ -452,8 +452,8 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     add_index "user_form_form_fields", ["user_form_id"], name: "index_user_form_form_fields_on_user_form_id", using: :btree
   
     create_table "user_forms", force: :cascade do |t|
-      t.bigint   "user_id"
-      t.bigint   "form_id"
+      t.integer  "user_id",    limit: 4
+      t.integer  "form_id",    limit: 4
       t.datetime "created_at",           null: false
       t.datetime "updated_at",           null: false
     end
@@ -462,8 +462,8 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     add_index "user_forms", ["user_id"], name: "index_user_forms_on_user_id", using: :btree
   
     create_table "user_permissions", force: :cascade do |t|
-      t.bigint   "user_id"
-      t.bigint   "permission_id"
+      t.integer  "user_id",       limit: 4
+      t.integer  "permission_id", limit: 4
       t.datetime "created_at",              null: false
       t.datetime "updated_at",              null: false
     end
@@ -486,7 +486,7 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.string   "last_sign_in_ip",        limit: 255
       t.datetime "created_at"
       t.datetime "updated_at"
-      t.bigint   "agency_id"
+      t.integer  "agency_id",              limit: 4
       t.string   "phone",                  limit: 255
       t.string   "address",                limit: 255
       t.string   "city",                   limit: 255
@@ -499,7 +499,7 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.boolean  "legacy",                                  default: false
       t.boolean  "inactive",                                default: false
       t.boolean  "confirmed",                               default: true
-      t.bigint   "legacy_id"
+      t.integer  "legacy_id",              limit: 4
       t.string   "phone2",                 limit: 255
       t.string   "phone3",                 limit: 255
       t.string   "best_time_to_call",      limit: 255
@@ -507,10 +507,10 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.string   "city2",                  limit: 255
       t.string   "state2",                 limit: 255
       t.string   "zip2",                   limit: 255
-      t.integer  "primary_address", limit: 4
+      t.integer  "primary_address",        limit: 4
       t.string   "avatar_file_name",       limit: 255
       t.string   "avatar_content_type",    limit: 255
-      t.bigint   "avatar_file_size"
+      t.integer  "avatar_file_size",       limit: 4
       t.datetime "avatar_updated_at"
       t.boolean  "super_user",                              default: false
     end
@@ -523,13 +523,13 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.string   "name",       limit: 255
       t.datetime "created_at",             null: false
       t.datetime "updated_at",             null: false
-      t.bigint   "legacy_id"
+      t.integer  "legacy_id",  limit: 4
       t.string   "short_name", limit: 255
     end
   
     create_table "workshop_age_ranges", force: :cascade do |t|
-      t.bigint   "workshop_id"
-      t.bigint   "age_range_id"
+      t.integer  "workshop_id",  limit: 4
+      t.integer  "age_range_id", limit: 4
       t.datetime "created_at",             null: false
       t.datetime "updated_at",             null: false
     end
@@ -538,8 +538,8 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     add_index "workshop_age_ranges", ["workshop_id"], name: "index_workshop_age_ranges_on_workshop_id", using: :btree
   
     create_table "workshop_logs", force: :cascade do |t|
-      t.bigint   "workshop_id"
-      t.bigint   "user_id"
+      t.integer  "workshop_id",                 limit: 4
+      t.integer  "user_id",                     limit: 4
       t.date     "date"
       t.integer  "rating",                      limit: 4,        default: 0
       t.text     "reaction",                    limit: 16777215
@@ -553,7 +553,7 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.text     "comments",                    limit: 16777215
       t.datetime "created_at",                                                   null: false
       t.datetime "updated_at",                                                   null: false
-      t.bigint   "project_id"
+      t.integer  "project_id",                  limit: 4
       t.boolean  "is_embodied_art_workshop",                     default: false
       t.integer  "num_participants_on_going",   limit: 4,        default: 0
       t.integer  "num_participants_first_time", limit: 4,        default: 0
@@ -564,8 +564,8 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     add_index "workshop_logs", ["workshop_id"], name: "index_workshop_logs_on_workshop_id", using: :btree
   
     create_table "workshop_resources", force: :cascade do |t|
-      t.bigint   "workshop_id"
-      t.bigint   "resource_id"
+      t.integer  "workshop_id", limit: 4
+      t.integer  "resource_id", limit: 4
       t.datetime "created_at",            null: false
       t.datetime "updated_at",            null: false
     end
@@ -574,15 +574,15 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
     add_index "workshop_resources", ["workshop_id"], name: "index_workshop_resources_on_workshop_id", using: :btree
   
     create_table "workshop_variations", force: :cascade do |t|
-      t.bigint   "workshop_id"
+      t.integer  "workshop_id",  limit: 4
       t.datetime "created_at",                                    null: false
       t.datetime "updated_at",                                    null: false
       t.text     "code",         limit: 16777215
       t.boolean  "inactive",                      default: true
-      t.integer  "ordering", limit: 4
+      t.integer  "ordering",     limit: 4
       t.string   "name",         limit: 255
       t.boolean  "legacy",                        default: false
-      t.bigint   "variation_id"
+      t.integer  "variation_id", limit: 4
     end
   
     add_index "workshop_variations", ["workshop_id"], name: "index_workshop_variations_on_workshop_id", using: :btree
@@ -591,8 +591,8 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.string   "title",                      limit: 255
       t.string   "full_name",                  limit: 255
       t.string   "author_location",            limit: 255
-      t.integer  "month", limit: 4
-      t.integer  "year", limit: 4
+      t.integer  "month",                      limit: 4
+      t.integer  "year",                       limit: 4
       t.text     "objective",                  limit: 16777215
       t.text     "materials",                  limit: 16777215
       t.text     "timeframe",                  limit: 16777215
@@ -619,9 +619,9 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.datetime "created_at",                                                  null: false
       t.datetime "updated_at",                                                  null: false
       t.boolean  "legacy",                                      default: false
-      t.bigint   "legacy_id"
-      t.bigint   "windows_type_id"
-      t.bigint   "user_id"
+      t.integer  "legacy_id",                  limit: 4
+      t.integer  "windows_type_id",            limit: 4
+      t.integer  "user_id",                    limit: 4
       t.integer  "led_count",                  limit: 4,        default: 0
       t.text     "objective_spanish",          limit: 16777215
       t.text     "materials_spanish",          limit: 16777215
@@ -639,7 +639,7 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.text     "tips_spanish",               limit: 16777215
       t.string   "thumbnail_file_name",        limit: 255
       t.string   "thumbnail_content_type",     limit: 255
-      t.bigint   "thumbnail_file_size"
+      t.integer  "thumbnail_file_size",        limit: 4
       t.datetime "thumbnail_updated_at"
       t.text     "optional_materials",         limit: 16777215
       t.text     "optional_materials_spanish", limit: 16777215
@@ -653,15 +653,15 @@ class CreateDatabase < ActiveRecord::Migration[4.2]
       t.text     "visualization_spanish",      limit: 16777215
       t.text     "misc1_spanish",              limit: 16777215
       t.text     "misc2_spanish",              limit: 16777215
-      t.integer  "time_intro", limit: 4
-      t.integer  "time_demonstration", limit: 4
-      t.integer  "time_warm_up", limit: 4
-      t.integer  "time_creation", limit: 4
-      t.integer  "time_closing", limit: 4
-      t.integer  "time_opening", limit: 4
+      t.integer  "time_intro",                 limit: 4
+      t.integer  "time_demonstration",         limit: 4
+      t.integer  "time_warm_up",               limit: 4
+      t.integer  "time_creation",              limit: 4
+      t.integer  "time_closing",               limit: 4
+      t.integer  "time_opening",               limit: 4
       t.string   "header_file_name",           limit: 255
       t.string   "header_content_type",        limit: 255
-      t.bigint   "header_file_size"
+      t.integer  "header_file_size",           limit: 4
       t.datetime "header_updated_at"
       t.text     "extra_field",                limit: 65535
       t.text     "extra_field_spanish",        limit: 65535

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,9 +10,9 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20250407002246) do
+ActiveRecord::Schema.define(version: 2025_04_07_002246) do
 
-  create_table "admins", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "admins", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "first_name", default: "", null: false
@@ -32,82 +31,82 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.index ["reset_password_token"], name: "index_admins_on_reset_password_token", unique: true
   end
 
-  create_table "age_ranges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "age_ranges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "windows_type_id"
+    t.integer "windows_type_id"
     t.index ["windows_type_id"], name: "index_age_ranges_on_windows_type_id"
   end
 
-  create_table "answer_options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "answer_options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "name"
     t.integer "order"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "owner_id"
+  create_table "attachments", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "owner_id"
     t.string "owner_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "file_file_name"
     t.string "file_content_type"
-    t.bigint "file_file_size"
+    t.integer "file_file_size"
     t.datetime "file_updated_at"
   end
 
-  create_table "banners", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "banners", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.text "content"
     t.boolean "show"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "bookmark_annotations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "bookmark_id"
-    t.text "annotation", size: :medium
+  create_table "bookmark_annotations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "bookmark_id"
+    t.text "annotation", limit: 16777215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["bookmark_id"], name: "index_bookmark_annotations_on_bookmark_id"
   end
 
-  create_table "bookmarks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "user_id"
+  create_table "bookmarks", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "user_id"
     t.string "bookmarkable_type"
-    t.bigint "bookmarkable_id"
+    t.integer "bookmarkable_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "metadatum_id"
+  create_table "categories", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "metadatum_id"
     t.string "name"
-    t.bigint "legacy_id"
+    t.integer "legacy_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "published", default: false
     t.index ["metadatum_id"], name: "index_categories_on_metadatum_id"
   end
 
-  create_table "categorizable_items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "categorizable_id"
+  create_table "categorizable_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "categorizable_id"
     t.string "categorizable_type"
-    t.bigint "category_id"
-    t.bigint "legacy_id"
+    t.integer "category_id"
+    t.integer "legacy_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "inactive", default: true
     t.index ["category_id"], name: "index_categorizable_items_on_category_id"
   end
 
-  create_table "ckeditor_assets", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "ckeditor_assets", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "data_file_name", null: false
     t.string "data_content_type"
-    t.bigint "data_file_size"
-    t.bigint "assetable_id"
+    t.integer "data_file_size"
+    t.integer "assetable_id"
     t.string "assetable_type", limit: 30
     t.string "type", limit: 30
     t.integer "width"
@@ -119,16 +118,16 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.index ["assetable_type", "type", "assetable_id"], name: "idx_ckeditor_assetable_type"
   end
 
-  create_table "faqs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "faqs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "question"
-    t.text "answer", size: :medium
+    t.text "answer", limit: 16777215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "inactive"
     t.integer "ordering"
   end
 
-  create_table "footers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "footers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "phone"
     t.string "children_program"
     t.string "adult_program"
@@ -137,27 +136,27 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "form_builders", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "form_builders", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "name"
     t.integer "owner_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "description", size: :medium
-    t.bigint "windows_type_id"
+    t.text "description", limit: 16777215
+    t.integer "windows_type_id"
     t.index ["windows_type_id"], name: "index_form_builders_on_windows_type_id"
   end
 
-  create_table "form_field_answer_options", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "form_field_id"
-    t.bigint "answer_option_id"
+  create_table "form_field_answer_options", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "form_field_id"
+    t.integer "answer_option_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["answer_option_id"], name: "index_form_field_answer_options_on_answer_option_id"
     t.index ["form_field_id"], name: "index_form_field_answer_options_on_form_field_id"
   end
 
-  create_table "form_fields", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "form_id"
+  create_table "form_fields", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "form_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "question"
@@ -167,33 +166,33 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.integer "ordering"
     t.boolean "is_required", default: true
     t.integer "status", default: 1
-    t.bigint "parent_id"
+    t.integer "parent_id"
     t.index ["form_id"], name: "index_form_fields_on_form_id"
   end
 
-  create_table "forms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "forms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "owner_type"
-    t.bigint "owner_id"
+    t.integer "owner_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "form_builder_id"
+    t.integer "form_builder_id"
     t.index ["form_builder_id"], name: "index_forms_on_form_builder_id"
   end
 
-  create_table "images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "owner_id"
+  create_table "images", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "owner_id"
     t.string "owner_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "file_file_name"
     t.string "file_content_type"
-    t.bigint "file_file_size"
+    t.integer "file_file_size"
     t.datetime "file_updated_at"
-    t.bigint "report_id"
+    t.integer "report_id"
     t.index ["owner_id"], name: "index_images_on_owner_id"
   end
 
-  create_table "locations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "locations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "city"
     t.string "state"
     t.string "country"
@@ -201,16 +200,16 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.datetime "updated_at", null: false
   end
 
-  create_table "media_files", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "media_files", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "file_file_name"
     t.string "file_content_type"
-    t.bigint "file_file_size"
+    t.integer "file_file_size"
     t.datetime "file_updated_at"
-    t.bigint "report_id"
-    t.bigint "workshop_log_id"
+    t.integer "report_id"
+    t.integer "workshop_log_id"
   end
 
-  create_table "metadata", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "metadata", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "name"
     t.string "legacy_id"
     t.datetime "created_at", null: false
@@ -218,20 +217,20 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.boolean "published", default: false
   end
 
-  create_table "monthly_reports", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "monthly_reports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "month"
-    t.bigint "project_id"
-    t.bigint "project_user_id"
+    t.integer "project_id"
+    t.integer "project_user_id"
     t.string "name"
     t.string "position"
     t.boolean "mail_evaluations"
     t.string "num_ongoing_participants"
     t.string "num_new_participants"
-    t.text "most_effective", size: :medium
-    t.text "most_challenging", size: :medium
-    t.text "goals_reached", size: :medium
-    t.text "goals", size: :medium
-    t.text "comments", size: :medium
+    t.text "most_effective", limit: 16777215
+    t.text "most_challenging", limit: 16777215
+    t.text "goals_reached", limit: 16777215
+    t.text "goals", limit: 16777215
+    t.text "comments", limit: 16777215
     t.boolean "call_requested"
     t.string "best_call_time"
     t.string "phone"
@@ -241,120 +240,120 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.index ["project_user_id"], name: "index_monthly_reports_on_project_user_id"
   end
 
-  create_table "notifications", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "notifications", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "notification_type"
     t.string "noticeable_type"
-    t.bigint "noticeable_id"
+    t.integer "noticeable_id"
   end
 
-  create_table "permissions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "security_cat"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "legacy_id"
+    t.integer "legacy_id"
   end
 
-  create_table "project_obligations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "project_obligations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "project_statuses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "project_statuses", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end
 
-  create_table "project_users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "agency_id"
-    t.bigint "user_id"
+  create_table "project_users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "agency_id"
+    t.integer "user_id"
     t.integer "position"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "project_id"
+    t.integer "project_id"
     t.string "filemaker_code"
     t.index ["agency_id"], name: "index_project_users_on_agency_id"
     t.index ["project_id"], name: "index_project_users_on_project_id"
     t.index ["user_id"], name: "index_project_users_on_user_id"
   end
 
-  create_table "projects", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "projects", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "name"
-    t.bigint "location_id"
+    t.integer "location_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "windows_type_id"
+    t.integer "windows_type_id"
     t.string "district"
     t.date "start_date"
     t.date "end_date"
     t.string "locality"
-    t.text "description", size: :medium
-    t.text "notes", size: :medium
+    t.text "description", limit: 16777215
+    t.text "notes", limit: 16777215
     t.string "filemaker_code"
     t.boolean "inactive", default: false
-    t.bigint "legacy_id"
+    t.integer "legacy_id"
     t.boolean "legacy", default: false
-    t.bigint "project_status_id"
+    t.integer "project_status_id"
     t.index ["location_id"], name: "index_projects_on_location_id"
     t.index ["project_status_id"], name: "index_projects_on_project_status_id"
     t.index ["windows_type_id"], name: "index_projects_on_windows_type_id"
   end
 
-  create_table "quotable_item_quotes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "quotable_item_quotes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "quotable_type"
-    t.bigint "quotable_id"
-    t.bigint "legacy_id"
-    t.bigint "quote_id"
+    t.integer "quotable_id"
+    t.integer "legacy_id"
+    t.integer "quote_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["quote_id"], name: "index_quotable_item_quotes_on_quote_id"
   end
 
-  create_table "quotes", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.text "quote", size: :medium
+  create_table "quotes", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.text "quote", limit: 16777215
     t.boolean "inactive", default: true
-    t.bigint "legacy_id"
+    t.integer "legacy_id"
     t.boolean "legacy", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "workshop_id"
+    t.integer "workshop_id"
     t.string "age"
     t.string "gender", limit: 1
     t.string "speaker_name"
     t.index ["workshop_id"], name: "index_quotes_on_workshop_id"
   end
 
-  create_table "report_form_field_answers", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "report_id"
-    t.bigint "form_field_id"
-    t.text "answer", size: :medium
+  create_table "report_form_field_answers", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "report_id"
+    t.integer "form_field_id"
+    t.text "answer", limit: 16777215
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.bigint "answer_option_id"
+    t.integer "answer_option_id"
     t.index ["answer_option_id"], name: "index_report_form_field_answers_on_answer_option_id"
     t.index ["form_field_id"], name: "index_report_form_field_answers_on_form_field_id"
     t.index ["report_id"], name: "index_report_form_field_answers_on_report_id"
   end
 
-  create_table "reports", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "reports", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "type"
-    t.bigint "owner_id"
+    t.integer "owner_id"
     t.string "owner_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "user_id"
-    t.bigint "project_id"
+    t.integer "user_id"
+    t.integer "project_id"
     t.date "date"
     t.integer "rating", default: 0
-    t.bigint "windows_type_id"
+    t.integer "windows_type_id"
     t.string "form_file_file_name"
     t.string "form_file_content_type"
-    t.bigint "form_file_file_size"
+    t.integer "form_file_file_size"
     t.datetime "form_file_updated_at"
-    t.bigint "workshop_id"
+    t.integer "workshop_id"
     t.string "workshop_name"
     t.string "other_description"
     t.boolean "has_attachment", default: false
@@ -369,77 +368,77 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.index ["windows_type_id"], name: "index_reports_on_windows_type_id"
   end
 
-  create_table "resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "resources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "title"
     t.string "author"
-    t.bigint "user_id"
-    t.text "text", size: :medium
+    t.integer "user_id"
+    t.text "text", limit: 16777215
     t.boolean "featured", default: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "kind"
-    t.bigint "workshop_id"
+    t.integer "workshop_id"
     t.boolean "male", default: false
     t.boolean "female", default: false
     t.string "url"
     t.boolean "inactive", default: true
     t.string "agency"
     t.boolean "legacy"
-    t.bigint "windows_type_id"
+    t.integer "windows_type_id"
     t.string "filemaker_code"
     t.integer "ordering"
-    t.bigint "legacy_id"
+    t.integer "legacy_id"
     t.index ["user_id"], name: "index_resources_on_user_id"
     t.index ["windows_type_id"], name: "index_resources_on_windows_type_id"
     t.index ["workshop_id"], name: "index_resources_on_workshop_id"
   end
 
-  create_table "sectorable_items", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "sectorable_id"
+  create_table "sectorable_items", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "sectorable_id"
     t.string "sectorable_type"
-    t.bigint "sector_id"
+    t.integer "sector_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "inactive", default: true
     t.index ["sector_id"], name: "index_sectorable_items_on_sector_id"
   end
 
-  create_table "sectors", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "sectors", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "published", default: false
   end
 
-  create_table "user_form_form_fields", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "form_field_id"
-    t.bigint "user_form_id"
-    t.text "text", size: :medium
+  create_table "user_form_form_fields", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "form_field_id"
+    t.integer "user_form_id"
+    t.text "text", limit: 16777215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["form_field_id"], name: "index_user_form_form_fields_on_form_field_id"
     t.index ["user_form_id"], name: "index_user_form_form_fields_on_user_form_id"
   end
 
-  create_table "user_forms", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "form_id"
+  create_table "user_forms", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "form_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["form_id"], name: "index_user_forms_on_form_id"
     t.index ["user_id"], name: "index_user_forms_on_user_id"
   end
 
-  create_table "user_permissions", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "user_id"
-    t.bigint "permission_id"
+  create_table "user_permissions", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "user_id"
+    t.integer "permission_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["permission_id"], name: "index_user_permissions_on_permission_id"
     t.index ["user_id"], name: "index_user_permissions_on_user_id"
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "users", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "first_name", default: ""
@@ -454,7 +453,7 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.string "last_sign_in_ip"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.bigint "agency_id"
+    t.integer "agency_id"
     t.string "phone"
     t.string "address"
     t.string "city"
@@ -462,12 +461,12 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.string "zip"
     t.date "birthday"
     t.string "subscribecode"
-    t.text "comment", size: :medium
-    t.text "notes", size: :medium
+    t.text "comment", limit: 16777215
+    t.text "notes", limit: 16777215
     t.boolean "legacy", default: false
     t.boolean "inactive", default: false
     t.boolean "confirmed", default: true
-    t.bigint "legacy_id"
+    t.integer "legacy_id"
     t.string "phone2"
     t.string "phone3"
     t.string "best_time_to_call"
@@ -478,7 +477,7 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.integer "primary_address"
     t.string "avatar_file_name"
     t.string "avatar_content_type"
-    t.bigint "avatar_file_size"
+    t.integer "avatar_file_size"
     t.datetime "avatar_updated_at"
     t.boolean "super_user", default: false
     t.index ["agency_id"], name: "index_users_on_agency_id"
@@ -486,40 +485,40 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  create_table "windows_types", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "windows_types", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "legacy_id"
+    t.integer "legacy_id"
     t.string "short_name"
   end
 
-  create_table "workshop_age_ranges", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "workshop_id"
-    t.bigint "age_range_id"
+  create_table "workshop_age_ranges", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "workshop_id"
+    t.integer "age_range_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["age_range_id"], name: "index_workshop_age_ranges_on_age_range_id"
     t.index ["workshop_id"], name: "index_workshop_age_ranges_on_workshop_id"
   end
 
-  create_table "workshop_logs", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "workshop_id"
-    t.bigint "user_id"
+  create_table "workshop_logs", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "workshop_id"
+    t.integer "user_id"
     t.date "date"
     t.integer "rating", default: 0
-    t.text "reaction", size: :medium
-    t.text "successes", size: :medium
-    t.text "challenges", size: :medium
-    t.text "suggestions", size: :medium
-    t.text "questions", size: :medium
+    t.text "reaction", limit: 16777215
+    t.text "successes", limit: 16777215
+    t.text "challenges", limit: 16777215
+    t.text "suggestions", limit: 16777215
+    t.text "questions", limit: 16777215
     t.boolean "lead_similar"
-    t.text "similarities", size: :medium
-    t.text "differences", size: :medium
-    t.text "comments", size: :medium
+    t.text "similarities", limit: 16777215
+    t.text "differences", limit: 16777215
+    t.text "comments", limit: 16777215
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "project_id"
+    t.integer "project_id"
     t.boolean "is_embodied_art_workshop", default: false
     t.integer "num_participants_on_going", default: 0
     t.integer "num_participants_first_time", default: 0
@@ -528,49 +527,49 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.index ["workshop_id"], name: "index_workshop_logs_on_workshop_id"
   end
 
-  create_table "workshop_resources", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "workshop_id"
-    t.bigint "resource_id"
+  create_table "workshop_resources", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "workshop_id"
+    t.integer "resource_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["resource_id"], name: "index_workshop_resources_on_resource_id"
     t.index ["workshop_id"], name: "index_workshop_resources_on_workshop_id"
   end
 
-  create_table "workshop_variations", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
-    t.bigint "workshop_id"
+  create_table "workshop_variations", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+    t.integer "workshop_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.text "code", size: :medium
+    t.text "code", limit: 16777215
     t.boolean "inactive", default: true
     t.integer "ordering"
     t.string "name"
     t.boolean "legacy", default: false
-    t.bigint "variation_id"
+    t.integer "variation_id"
     t.index ["workshop_id"], name: "index_workshop_variations_on_workshop_id"
   end
 
-  create_table "workshops", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
+  create_table "workshops", id: :integer, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb3", force: :cascade do |t|
     t.string "title"
     t.string "full_name"
     t.string "author_location"
     t.integer "month"
     t.integer "year"
-    t.text "objective", size: :medium
-    t.text "materials", size: :medium
-    t.text "timeframe", size: :medium
-    t.text "age_range", size: :medium
-    t.text "setup", size: :medium
-    t.text "instructions", size: :medium
-    t.text "warm_up", size: :medium
-    t.text "creation", size: :medium
-    t.text "closing", size: :medium
-    t.text "misc_instructions", size: :medium
-    t.text "project", size: :medium
-    t.text "description", size: :medium
-    t.text "notes", size: :medium
-    t.text "timestamps", size: :medium
-    t.text "tips", size: :medium
+    t.text "objective", limit: 16777215
+    t.text "materials", limit: 16777215
+    t.text "timeframe", limit: 16777215
+    t.text "age_range", limit: 16777215
+    t.text "setup", limit: 16777215
+    t.text "instructions", limit: 16777215
+    t.text "warm_up", limit: 16777215
+    t.text "creation", limit: 16777215
+    t.text "closing", limit: 16777215
+    t.text "misc_instructions", limit: 16777215
+    t.text "project", limit: 16777215
+    t.text "description", limit: 16777215
+    t.text "notes", limit: 16777215
+    t.text "timestamps", limit: 16777215
+    t.text "tips", limit: 16777215
     t.string "pub_issue"
     t.string "misc1"
     t.string "misc2"
@@ -582,40 +581,40 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.boolean "legacy", default: false
-    t.bigint "legacy_id"
-    t.bigint "windows_type_id"
-    t.bigint "user_id"
+    t.integer "legacy_id"
+    t.integer "windows_type_id"
+    t.integer "user_id"
     t.integer "led_count", default: 0
-    t.text "objective_spanish", size: :medium
-    t.text "materials_spanish", size: :medium
-    t.text "timeframe_spanish", size: :medium
-    t.text "age_range_spanish", size: :medium
-    t.text "setup_spanish", size: :medium
-    t.text "instructions_spanish", size: :medium
-    t.text "project_spanish", size: :medium
-    t.text "warm_up_spanish", size: :medium
-    t.text "creation_spanish", size: :medium
-    t.text "closing_spanish", size: :medium
-    t.text "misc_instructions_spanish", size: :medium
-    t.text "description_spanish", size: :medium
-    t.text "notes_spanish", size: :medium
-    t.text "tips_spanish", size: :medium
+    t.text "objective_spanish", limit: 16777215
+    t.text "materials_spanish", limit: 16777215
+    t.text "timeframe_spanish", limit: 16777215
+    t.text "age_range_spanish", limit: 16777215
+    t.text "setup_spanish", limit: 16777215
+    t.text "instructions_spanish", limit: 16777215
+    t.text "project_spanish", limit: 16777215
+    t.text "warm_up_spanish", limit: 16777215
+    t.text "creation_spanish", limit: 16777215
+    t.text "closing_spanish", limit: 16777215
+    t.text "misc_instructions_spanish", limit: 16777215
+    t.text "description_spanish", limit: 16777215
+    t.text "notes_spanish", limit: 16777215
+    t.text "tips_spanish", limit: 16777215
     t.string "thumbnail_file_name"
     t.string "thumbnail_content_type"
-    t.bigint "thumbnail_file_size"
+    t.integer "thumbnail_file_size"
     t.datetime "thumbnail_updated_at"
-    t.text "optional_materials", size: :medium
-    t.text "optional_materials_spanish", size: :medium
-    t.text "introduction", size: :medium
-    t.text "introduction_spanish", size: :medium
-    t.text "demonstration", size: :medium
-    t.text "demonstration_spanish", size: :medium
-    t.text "opening_circle", size: :medium
-    t.text "opening_circle_spanish", size: :medium
-    t.text "visualization", size: :medium
-    t.text "visualization_spanish", size: :medium
-    t.text "misc1_spanish", size: :medium
-    t.text "misc2_spanish", size: :medium
+    t.text "optional_materials", limit: 16777215
+    t.text "optional_materials_spanish", limit: 16777215
+    t.text "introduction", limit: 16777215
+    t.text "introduction_spanish", limit: 16777215
+    t.text "demonstration", limit: 16777215
+    t.text "demonstration_spanish", limit: 16777215
+    t.text "opening_circle", limit: 16777215
+    t.text "opening_circle_spanish", limit: 16777215
+    t.text "visualization", limit: 16777215
+    t.text "visualization_spanish", limit: 16777215
+    t.text "misc1_spanish", limit: 16777215
+    t.text "misc2_spanish", limit: 16777215
     t.integer "time_intro"
     t.integer "time_demonstration"
     t.integer "time_warm_up"
@@ -624,7 +623,7 @@ ActiveRecord::Schema.define(version: 20250407002246) do
     t.integer "time_opening"
     t.string "header_file_name"
     t.string "header_content_type"
-    t.bigint "header_file_size"
+    t.integer "header_file_size"
     t.datetime "header_updated_at"
     t.text "extra_field"
     t.text "extra_field_spanish"


### PR DESCRIPTION
two things:

- update PKs and FKs back to integer from bigint
- The db/archived migrations are not run. They are archived files kept for informational purposes only. We will remove them entirely after this PR is merged in. That would declutter the repo while retaining these files in git history.