### PR TITLE
break UsersController again & fix resource images

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -85,23 +85,23 @@ class UsersController < ApplicationController
     @user == current_user || current_user.liaison_in_projects?(@user.projects)
   end
 
-  def user_params
-    params.require(:user).permit(
-      :email, :first_name, :last_name,
-      :phone, :phone2, :phone3, :best_time_to_call,
-      :birthday, :address, :city, :state, :zip, :address2,
-      :city2, :state2, :zip2, :primary_address, :notes, :avatar,
-      project_users_attributes: [:project_id, :position, :_destroy, :id]
-    )
-  end
+  # def user_params
+  #   params.require(:user).permit(
+  #     :email, :first_name, :last_name,
+  #     :phone, :phone2, :phone3, :best_time_to_call,
+  #     :birthday, :address, :city, :state, :zip, :address2,
+  #     :city2, :state2, :zip2, :primary_address, :notes, :avatar,
+  #     project_users_attributes: [:project_id, :position, :_destroy, :id]
+  #   )
+  # end
 
-  def id_param
-    params[:id]
-  end
+  # def id_param
+  #   params[:id]
+  # end
 
-  def password_param
-    params[:user][:password]
-  end
+  # def password_param
+  #   params[:user][:password]
+  # end
 
   def pass_params
     # NOTE: Using `strong_parameters` gem

--- a/app/decorators/resource_decorator.rb
+++ b/app/decorators/resource_decorator.rb
@@ -24,7 +24,7 @@ class ResourceDecorator < Draper::Decorator
 
   def main_image(size = nil)
     return if kind == 'Theme'
-    images.first.file if images.any?
+    images.first.file.url if images.any?
   end
 
   def flex_text

--- a/app/views/resources/show.html.erb
+++ b/app/views/resources/show.html.erb
@@ -21,7 +21,7 @@
               <%= image_tag @resource.main_image, class: 'resource-image__large' %>
               <br/>
             <% else %>
-                <b>Image Unavailable</b>
+              <%= image_tag @resource.main_image %>
             <% end %>
           <% end %>
         </div>


### PR DESCRIPTION
Why did i revert the UsersController param helper method change?
These param helper methods are commented out in the production app. This
causes any attempt to route to actions that use those param helper 
methods to fail. Uncommenting them makes those routes accessible. Those 
now routable actions can create new users and edit existing ones. It is 
probably best to keep those methods commented out. I am guessing we will end up removing the methods and the associated actions.

Looks like image_tag tightened up in 5.2 and won't play nicely with Paperclip::Attachment objects. I updated the ResourceDecorator#main_image to return the file's url instead of the file itself. The #main_image is used in two erb's that i can find. This change appears to fix the use of image_tags on those views.
